### PR TITLE
fmt.Sprintf inside panic call

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ for i := 0; i < 256; i++ {
     l.Add(i, nil)
 }
 if l.Len() != 128 {
-    panic("bad len: %v", l.Len())
+    panic(fmt.Sprintf("bad len: %v", l.Len()))
 }
 ```


### PR DESCRIPTION
Ran the example directly, panic only takes one argument. Switched it over to using `fmt.Sprintf`.