### PR TITLE
Add an 'onEvict' function called when an element is removed.

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -47,9 +47,9 @@ func (c *Cache) Purge() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	e := c.evictList.Front()
+	e := c.evictList.Back()
 	for e != nil {
-		n := e.Next()
+		n := e.Prev()
 		c.removeElement(e)
 		e = n
 	}

--- a/lru.go
+++ b/lru.go
@@ -15,7 +15,7 @@ type Cache struct {
 	evictList *list.List
 	items     map[interface{}]*list.Element
 	lock      sync.RWMutex
-	onEvicted func(key interface{}, value interface{})
+	OnEvicted func(key interface{}, value interface{})
 }
 
 // entry is used to hold a value in the evictList
@@ -132,7 +132,7 @@ func (c *Cache) removeElement(e *list.Element) {
 	c.evictList.Remove(e)
 	kv := e.Value.(*entry)
 	delete(c.items, kv.key)
-	if c.onEvicted != nil {
-		c.onEvicted(kv.key, kv.value)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
 	}
 }

--- a/lru.go
+++ b/lru.go
@@ -44,9 +44,14 @@ func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) 
 
 // Purge is used to completely clear the cache
 func (c *Cache) Purge() {
-	// Evict each element in the list.
-	for c.Len() > 0 {
-		c.RemoveOldest()
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	e := c.evictList.Front()
+	for e != nil {
+		n := e.Next()
+		c.removeElement(e)
+		e = n
 	}
 }
 

--- a/lru.go
+++ b/lru.go
@@ -47,12 +47,14 @@ func (c *Cache) Purge() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	e := c.evictList.Back()
-	for e != nil {
-		n := e.Prev()
-		c.removeElement(e)
-		e = n
+	if c.onEvicted != nil {
+		for k, v := range c.items {
+			c.onEvicted(k, v.Value)
+		}
 	}
+
+	c.evictList = list.New()
+	c.items = make(map[interface{}]*list.Element, c.size)
 }
 
 // Add adds a value to the cache.

--- a/lru_test.go
+++ b/lru_test.go
@@ -3,14 +3,13 @@ package lru
 import "testing"
 
 func TestLRU(t *testing.T) {
-	l, err := New(128)
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		evictCounter += 1
+	}
+	l, err := NewWithEvict(128, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
-	}
-
-	evictCounter := 0
-	l.OnEvicted = func(k interface{}, v interface{}) {
-		evictCounter += 1
 	}
 
 	for i := 0; i < 256; i++ {

--- a/lru_test.go
+++ b/lru_test.go
@@ -7,12 +7,23 @@ func TestLRU(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+
+	evictCounter := 0
+	l.onEvicted = func(k interface{}, v interface{}) {
+		evictCounter += 1
+	}
+
 	for i := 0; i < 256; i++ {
 		l.Add(i, i)
 	}
 	if l.Len() != 128 {
 		t.Fatalf("bad len: %v", l.Len())
 	}
+
+	if evictCounter != 128 {
+		t.Fatalf("bad evict count: %v", evictCounter)
+	}
+
 	for _, k := range l.Keys() {
 		if v, ok := l.Get(k); !ok || v != k {
 			t.Fatalf("bad key: %v", k)

--- a/lru_test.go
+++ b/lru_test.go
@@ -9,7 +9,7 @@ func TestLRU(t *testing.T) {
 	}
 
 	evictCounter := 0
-	l.onEvicted = func(k interface{}, v interface{}) {
+	l.OnEvicted = func(k interface{}, v interface{}) {
 		evictCounter += 1
 	}
 


### PR DESCRIPTION
I wanted to keep an LRU cache of open files, so I need a hook for closing the files as they're evicted from the cache.

A side effect is that the Purge operation is now probably slower, since we have to remove each element individually to ensure that `OnEvicted` gets called for each element. If that is important, I could check if the `OnEvicted` function is missing, and if so purge the original way.