### PR TITLE
simplify implementation of FillingCache

### DIFF
--- a/fill.go
+++ b/fill.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-type FillFunc func() (interface{}, time.Time)
+type FillFunc func(key interface{}) (interface{}, time.Time, error)
 
 // Cache is a thread-safe fixed size LRU cache.
 type FillingCache struct {
@@ -18,8 +18,7 @@ type FillingCache struct {
 	evictList *list.List
 	items     map[interface{}]*list.Element
 	lock      sync.RWMutex
-
-	fill func(key interface{}) (interface{}, time.Time, error)
+	fill      FillFunc
 }
 
 // entry is used to hold a value in the evictList
@@ -32,7 +31,7 @@ type exp_entry struct {
 }
 
 // New creates an LRU of the given size
-func NewFilling(size int) (*FillingCache, error) {
+func NewFilling(size int, f FillFunc) (*FillingCache, error) {
 	if size <= 0 {
 		return nil, errors.New("Must provide a positive size")
 	}
@@ -40,6 +39,7 @@ func NewFilling(size int) (*FillingCache, error) {
 		size:      size,
 		evictList: list.New(),
 		items:     make(map[interface{}]*list.Element, size),
+		fill:      f,
 	}
 	return c, nil
 }

--- a/fill.go
+++ b/fill.go
@@ -1,0 +1,103 @@
+// This package provides a simple LRU cache. It is based on the
+// LRU implementation in groupcache:
+// https://github.com/golang/groupcache/tree/master/lru
+package lru
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+	"time"
+)
+
+type FillFunc func() (interface{}, time.Time)
+
+// Cache is a thread-safe fixed size LRU cache.
+type FillingCache struct {
+	size      int
+	evictList *list.List
+	items     map[interface{}]*list.Element
+	lock      sync.RWMutex
+
+	fill func(key interface{}) (interface{}, time.Time, error)
+}
+
+// entry is used to hold a value in the evictList
+type exp_entry struct {
+	key   interface{}
+	value interface{}
+	exp   time.Time
+	err   error
+	wg    sync.WaitGroup
+}
+
+// New creates an LRU of the given size
+func NewFilling(size int) (*FillingCache, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c := &FillingCache{
+		size:      size,
+		evictList: list.New(),
+		items:     make(map[interface{}]*list.Element, size),
+	}
+	return c, nil
+}
+
+// looks up a key's value from the cache, if it is not present get it
+func (c *FillingCache) Get(key interface{}) (value interface{}, err error) {
+	c.lock.Lock()
+
+	entry, ok := c.items[key]
+	if ok {
+		c.lock.Unlock()
+		casted := entry.Value.(*exp_entry)
+		casted.wg.Wait()
+
+		if time.Now().Before(casted.exp) {
+			c.evictList.MoveToFront(entry)
+			return casted.value, casted.err
+		}
+
+		//in the case where multiple clients are waiting,
+		//and then they receive an expired object
+		//they will now thunder (They will all try to get the value)
+		//thats a really unlikely failure
+		c.lock.Lock()
+	}
+
+	casted := &exp_entry{key: key}
+	casted.wg.Add(1) //stop clients from returning with stale data
+
+	entry = c.evictList.PushFront(casted)
+	c.items[key] = entry
+
+	//free up the map while we fetch our object
+	c.lock.Unlock()
+	casted.value, casted.exp, casted.err = c.fill(key)
+	casted.wg.Done()
+
+	//re-lock to trim set
+	c.lock.Lock()
+	if c.evictList.Len() > c.size {
+		c.removeOldest()
+	}
+	c.lock.Unlock()
+
+	return casted.value, casted.err
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *FillingCache) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *FillingCache) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*exp_entry)
+	delete(c.items, kv.key)
+}

--- a/fill_test.go
+++ b/fill_test.go
@@ -1,107 +1,167 @@
 package lru
 
 import (
-	"sync"
+	"errors"
 	"testing"
 	"time"
 )
 
-func TestFillingLRU(t *testing.T) {
+type filler struct {
+	value   int
+	err     error
+	blocker chan struct{}
+	timeout time.Duration
+}
 
-	i := 0
-	l, err := NewFilling(1, func(key interface{}) (interface{}, time.Time, error) {
-		i++
-		return i, time.Now().Add(time.Second), nil
-	})
+func (fr *filler) Fill(key interface{}) (interface{}, time.Time, error) {
+	fr.value++
+	if fr.blocker != nil {
+		<-fr.blocker
+	}
+	return fr.value, time.Now().Add(fr.timeout), fr.err
+}
+
+func TestFillingLRU(t *testing.T) {
+	fr := filler{timeout: 10 * time.Second}
+	fc := NewFillingCache(1, &fr)
 
 	//should fill
-	val, err := l.Get("asdf")
+	val, err := fc.Get("asdf")
 	if val != 1 {
-		t.Error("expected 1")
+		t.Errorf("expected 1 got %d", val)
 	}
 	if err != nil {
 		t.Error("expected no errors")
 	}
 
 	//should returned cached version
-	val, err = l.Get("asdf")
+	val, err = fc.Get("asdf")
 	if val != 1 {
-		t.Error("expected 1")
+		t.Errorf("expected cached 1 got %d", val)
 	}
 	if err != nil {
 		t.Error("expected no errors")
 	}
 
 	//should fill
-	val, err = l.Get("something else")
+	val, err = fc.Get("something else")
 	if val != 2 {
-		t.Error("expected 2")
+		t.Errorf("expected 2 got %d", val)
 	}
 	if err != nil {
 		t.Error("expected no errors")
 	}
 
 	//we expect this goes to 3, since the original asdf should now be evicted
-	val, err = l.Get("asdf")
+	val, err = fc.Get("asdf")
 	if val != 3 {
-		t.Error("expected 3")
+		t.Errorf("expected 3 got %d", val)
 	}
 	if err != nil {
 		t.Error("expected no errors")
 	}
+
+	// evict "asdf"
+	val, err = fc.Get("something else")
+	if val != 4 {
+		t.Errorf("expected 4 got %d", val)
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+
+	// expire right away
+	fr.timeout = 0
+	val, err = fc.Get("asdf")
+	if val != 5 {
+		t.Errorf("expected 5 got %d", val)
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+
+	val, err = fc.Get("asdf")
+	if val != 6 {
+		t.Errorf("expected 6 got %d", val)
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+
+	// expire with a bit delay
+	fr.timeout = 10 * time.Millisecond
+	// evict "asdf"
+	val, err = fc.Get("something else")
+	if val != 7 {
+		t.Errorf("expected 7 got %d", val)
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+	val, err = fc.Get("asdf")
+	if val != 8 {
+		t.Errorf("expected 8 got %d", val)
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+	time.Sleep(50 * time.Millisecond)
+	val, err = fc.Get("asdf")
+	if val != 9 {
+		t.Errorf("expected 9 got %d", val)
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+
+	// fill error
+	fr.err = errors.New("fill error")
+	fr.timeout = time.Second
+	_, err = fc.Get("something else")
+	if err == nil {
+		t.Error("expect err %v", fr.err)
+	}
 }
 
-//Test thundering horde
-func TestFillingLRUThunderingHorde(t *testing.T) {
+func TestFillingLRUWaitForFilling(t *testing.T) {
+	blocker := make(chan struct{}, 1)
+	fr := filler{
+		blocker: blocker,
+		timeout: 10 * time.Second,
+	}
+	fc := NewFillingCache(1, &fr)
 
-	i := 0
-	l, _ := NewFilling(1, func(key interface{}) (interface{}, time.Time, error) {
-		i++
-		return i, time.Now().Add(time.Second), nil
-	})
-
-	wg := sync.WaitGroup{}
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			val, err := l.Get("asdf")
+	chs := make([]chan struct{}, 100)
+	for i := 0; i < len(chs); i++ {
+		chs[i] = make(chan struct{}, 1)
+		go func(ch chan struct{}) {
+			val, err := fc.Get("asdf")
 			if val != 1 {
-				t.Error("expected 1")
+				t.Errorf("expected 1 got %d", val)
 			}
 			if err != nil {
 				t.Error("expected no errors")
 			}
-
-		}()
+			ch <- struct{}{}
+		}(chs[i])
 	}
 
-	wg.Wait()
-}
-
-func TestFillingLRUThunderingHordeBadExpiration(t *testing.T) {
-
-	i := 0
-	l, _ := NewFilling(1, func(key interface{}) (interface{}, time.Time, error) {
-		i++
-		return i, time.Now().Add(-time.Second), nil
-	})
-
-	wg := sync.WaitGroup{}
-
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			wg.Done()
-			_, _ = l.Get("asdf")
-
-		}()
+	for i := 0; i < len(chs); i++ {
+		select {
+		case <-chs[i]:
+			t.Errorf("expected client %d to block", i)
+		default:
+		}
 	}
 
-	wg.Wait()
-	//when they all trample and get a bad expiration, they continue to trample
-	if i != 100 {
-		t.Error("Expected 100")
+	blocker <- struct{}{}
+
+	tm := time.After(100 * time.Millisecond)
+	for i := 0; i < len(chs); i++ {
+		select {
+		case <-chs[i]:
+		case <-tm:
+			t.Errorf("unexpected timeout")
+		}
 	}
 }

--- a/fill_test.go
+++ b/fill_test.go
@@ -8,13 +8,11 @@ import (
 
 func TestFillingLRU(t *testing.T) {
 
-	l, err := NewFilling(1)
 	i := 0
-
-	l.fill = func(key interface{}) (interface{}, time.Time, error) {
+	l, err := NewFilling(1, func(key interface{}) (interface{}, time.Time, error) {
 		i++
 		return i, time.Now().Add(time.Second), nil
-	}
+	})
 
 	//should fill
 	val, err := l.Get("asdf")
@@ -56,13 +54,11 @@ func TestFillingLRU(t *testing.T) {
 //Test thundering horde
 func TestFillingLRUThunderingHorde(t *testing.T) {
 
-	l, _ := NewFilling(1)
 	i := 0
-
-	l.fill = func(key interface{}) (interface{}, time.Time, error) {
+	l, _ := NewFilling(1, func(key interface{}) (interface{}, time.Time, error) {
 		i++
 		return i, time.Now().Add(time.Second), nil
-	}
+	})
 
 	wg := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
@@ -86,13 +82,11 @@ func TestFillingLRUThunderingHorde(t *testing.T) {
 
 func TestFillingLRUThunderingHordeBadExpiration(t *testing.T) {
 
-	l, _ := NewFilling(1)
 	i := 0
-
-	l.fill = func(key interface{}) (interface{}, time.Time, error) {
+	l, _ := NewFilling(1, func(key interface{}) (interface{}, time.Time, error) {
 		i++
 		return i, time.Now().Add(-time.Second), nil
-	}
+	})
 
 	wg := sync.WaitGroup{}
 

--- a/fill_test.go
+++ b/fill_test.go
@@ -1,0 +1,113 @@
+package lru
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFillingLRU(t *testing.T) {
+
+	l, err := NewFilling(1)
+	i := 0
+
+	l.fill = func(key interface{}) (interface{}, time.Time, error) {
+		i++
+		return i, time.Now().Add(time.Second), nil
+	}
+
+	//should fill
+	val, err := l.Get("asdf")
+	if val != 1 {
+		t.Error("expected 1")
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+
+	//should returned cached version
+	val, err = l.Get("asdf")
+	if val != 1 {
+		t.Error("expected 1")
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+
+	//should fill
+	val, err = l.Get("something else")
+	if val != 2 {
+		t.Error("expected 2")
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+
+	//we expect this goes to 3, since the original asdf should now be evicted
+	val, err = l.Get("asdf")
+	if val != 3 {
+		t.Error("expected 3")
+	}
+	if err != nil {
+		t.Error("expected no errors")
+	}
+}
+
+//Test thundering horde
+func TestFillingLRUThunderingHorde(t *testing.T) {
+
+	l, _ := NewFilling(1)
+	i := 0
+
+	l.fill = func(key interface{}) (interface{}, time.Time, error) {
+		i++
+		return i, time.Now().Add(time.Second), nil
+	}
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			val, err := l.Get("asdf")
+			if val != 1 {
+				t.Error("expected 1")
+			}
+			if err != nil {
+				t.Error("expected no errors")
+			}
+
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestFillingLRUThunderingHordeBadExpiration(t *testing.T) {
+
+	l, _ := NewFilling(1)
+	i := 0
+
+	l.fill = func(key interface{}) (interface{}, time.Time, error) {
+		i++
+		return i, time.Now().Add(-time.Second), nil
+	}
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			_, _ = l.Get("asdf")
+
+		}()
+	}
+
+	wg.Wait()
+	//when they all trample and get a bad expiration, they continue to trample
+	if i != 100 {
+		t.Error("Expected 100")
+	}
+}


### PR DESCRIPTION
- treat expired cache entry the same as a new entry
- ensure the expiration time returned from Fill is sane