### PR TITLE
onEvicted Purge value fix

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -49,7 +49,7 @@ func (c *Cache) Purge() {
 
 	if c.onEvicted != nil {
 		for k, v := range c.items {
-			c.onEvicted(k, v.Value)
+			c.onEvicted(k, v.Value.(*entry).value)
 		}
 	}
 

--- a/lru_test.go
+++ b/lru_test.go
@@ -5,6 +5,9 @@ import "testing"
 func TestLRU(t *testing.T) {
 	evictCounter := 0
 	onEvicted := func(k interface{}, v interface{}) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+		}
 		evictCounter += 1
 	}
 	l, err := NewWithEvict(128, onEvicted)


### PR DESCRIPTION
evict in Purge was not returning value, but *lru.entry. The bug was fixed, and associated test added.