### PR TITLE
Change the Lock in Get to RLock

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -84,8 +84,8 @@ func (c *Cache) Add(key, value interface{}) bool {
 
 // Get looks up a key's value from the cache.
 func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)


### PR DESCRIPTION
I noticed that there is a Lock being set on the Get method which is not necessary if only read ops are bing done.
Many routines can call RLock() at the same time without problem, but only one routine can Lock() at the same time, and not while it is RLock'ed

This should allow more concurrent reading