### PR TITLE
Fixed potential memory leak from calling Purge very often

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -47,17 +47,15 @@ func (c *Cache) Purge() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if c.onEvicted != nil {
-		for k, v := range c.items {
+	for k, v := range c.items {
+		if c.onEvicted != nil {
 			c.onEvicted(k, v.Value.(*entry).value)
 		}
+
+		delete(c.items, k)
 	}
 
 	c.evictList.Init()
-
-	for k := range c.items {
-		delete(c.items, k)
-	}
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occured.

--- a/lru.go
+++ b/lru.go
@@ -53,8 +53,11 @@ func (c *Cache) Purge() {
 		}
 	}
 
-	c.evictList = list.New()
-	c.items = make(map[interface{}]*list.Element, c.size)
+	c.evictList.Init()
+
+	for k := range c.items {
+		delete(c.items, k)
+	}
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occured.


### PR DESCRIPTION
We're using the LRU in a situation where we are purging the cache fairly often.  The original code was creating a new list and map during every purge.  This pull request resets the original list and map, so it doesn't create any additional garbage.