### PR TITLE
Remove capacity specified in `make`

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -36,7 +36,7 @@ func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) 
 	c := &Cache{
 		size:      size,
 		evictList: list.New(),
-		items:     make(map[interface{}]*list.Element, size),
+		items:     make(map[interface{}]*list.Element),
 		onEvicted: onEvicted,
 	}
 	return c, nil


### PR DESCRIPTION
I have an application that uses many LRU caches, most of which we expect to stay small but allow outliers to grow. Unfortunately we can't set the capacity very high right now because the `make` on the internal items map specifies the maximum as its capacity.

You may prefer it as-is and if so feel free to say so and close this out, I'll just have to work around it. 

However for most programs not specifying capacity seems more optimal. in cases where the cache is short-lived or otherwise not likely to fill up this can provide big memory savings. In cases where the cache is long-lived, it will extend itself up to capacity fairly quickly and stay there, not much garbage/overhead. Only reason I could see for leaving it as-is is to prevent `items` from taking *any* more capacity than it requires.

One other alternative would be an alternate constructor that does not specify the initial capacity.