### PR TITLE
Adds an Adaptive Replacement Cache

### DIFF
--- a/arc.go
+++ b/arc.go
@@ -212,10 +212,18 @@ func (c *ARCCache) Keys() []interface{} {
 func (c *ARCCache) Remove(key interface{}) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.t1.Remove(key)
-	c.t2.Remove(key)
-	c.b1.Remove(key)
-	c.b2.Remove(key)
+	if c.t1.Remove(key) {
+		return
+	}
+	if c.t2.Remove(key) {
+		return
+	}
+	if c.b1.Remove(key) {
+		return
+	}
+	if c.b2.Remove(key) {
+		return
+	}
 }
 
 // Purge is used to clear the cache

--- a/arc.go
+++ b/arc.go
@@ -1,0 +1,234 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/internal"
+)
+
+// ARCCache is a thread-safe fixed size Adaptive Replacement Cache (ARC).
+// ARC is an enhancement over the standard LRU cache in that tracks both
+// frequency and recency of use. This avoids a burst in access to new
+// entries from evicting the frequently used older entries. It adds some
+// additional tracking overhead to a standard LRU cache.
+type ARCCache struct {
+	size int // Size is the total capacity of the cache
+	p    int // P is the dynamic preference towards T1 or T2
+
+	t1 *internal.LRU // T1 is the LRU for recently accessed items
+	b1 *internal.LRU // B1 is the LRU for evictions from t1
+
+	t2 *internal.LRU // T2 is the LRU for frequently accessed items
+	b2 *internal.LRU // B2 is the LRU for evictions from t2
+
+	lock sync.RWMutex
+}
+
+// NewARC creates an ARC of the given size
+func NewARC(size int) (*ARCCache, error) {
+	// Create the sub LRUs
+	b1, err := internal.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := internal.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t1, err := internal.NewLRU(size, func(k, v interface{}) {
+		// Evict from T1 adds to B1
+		b1.Add(k, nil)
+	})
+	if err != nil {
+		return nil, err
+	}
+	t2, err := internal.NewLRU(size, func(k, v interface{}) {
+		// Evict from T2 adds to B2
+		b2.Add(k, nil)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the ARC
+	c := &ARCCache{
+		size: size,
+		p:    0,
+		t1:   t1,
+		b1:   b1,
+		t2:   t2,
+		b2:   b2,
+	}
+	return c, nil
+}
+
+// Get looks up a key's value from the cache.
+func (c *ARCCache) Get(key interface{}) (interface{}, bool) {
+	// Check if the value is contained in T1 (recent), and potentially
+	// promote it to frequent T2
+	if val, ok := c.t1.Peek(key); ok {
+		c.t1.Remove(key)
+		c.t2.Add(key, val)
+		return val, ok
+	}
+
+	// Check if the value is contained in T2 (frequent)
+	val, ok := c.t2.Get(key)
+	if ok {
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+// Add adds a value to the cache.
+func (c *ARCCache) Add(key, value interface{}) {
+	// Check if the value is contained in T1 (recent), and potentially
+	// promote it to frequent T2
+	if c.t1.Contains(key) {
+		c.t1.Remove(key)
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if the value is already in T2 (frequent) and update it
+	if c.t2.Contains(key) {
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evitcted as part of the
+	// recently used list
+	if c.b1.Contains(key) {
+		// T1 set is too small, increase P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b2Len > b1Len {
+			delta = b2Len / b1Len
+		}
+		if c.p+delta >= c.size {
+			c.p = c.size
+		} else {
+			c.p += delta
+		}
+
+		// Make room in the cache
+		c.replace(key)
+
+		// Remove from B1
+		c.b1.Remove(key)
+
+		// Add the key to the frequently used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// frequently used list
+	if c.b2.Contains(key) {
+		// T2 set is too small, decrease P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b1Len > b2Len {
+			delta = b1Len / b2Len
+		}
+		if delta >= c.p {
+			c.p = 0
+		} else {
+			c.p -= delta
+		}
+
+		// Make room in the cache
+		c.replace(key)
+
+		// Remove from B2
+		c.b2.Remove(key)
+
+		// Add the key to the frequntly used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if any entries need to be evicted
+	t1Len := c.t1.Len()
+	b1Len := c.b1.Len()
+	if t1Len+b1Len == c.size {
+		if t1Len == c.size {
+			c.t1.RemoveOldest()
+		} else {
+			c.b1.RemoveOldest()
+			c.replace(key)
+		}
+	} else {
+		t2Len := c.t2.Len()
+		b2Len := c.b2.Len()
+		total := t1Len + t2Len + b1Len + b2Len
+		if total >= c.size {
+			if total == 2*c.size {
+				c.b2.RemoveOldest()
+			}
+			c.replace(key)
+		}
+	}
+
+	// Add to the recently seen list
+	c.t1.Add(key, value)
+	return
+}
+
+// replace is used to adaptively evict from either T1 or T2
+// based on the current learned value of P
+func (c *ARCCache) replace(key interface{}) {
+	t1Len := c.t1.Len()
+	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && c.b2.Contains(key))) {
+		c.t1.RemoveOldest()
+	} else {
+		c.t2.RemoveOldest()
+	}
+}
+
+// Len returns the number of cached entries
+func (c *ARCCache) Len() int {
+	return c.t1.Len() + c.t2.Len()
+}
+
+// Keys returns all the cached keys
+func (c *ARCCache) Keys() []interface{} {
+	k1 := c.t1.Keys()
+	k2 := c.t2.Keys()
+	return append(k1, k2...)
+}
+
+// Remove is used to perge a key from the cache
+func (c *ARCCache) Remove(key interface{}) {
+	c.t1.Remove(key)
+	c.t2.Remove(key)
+	c.b1.Remove(key)
+	c.b2.Remove(key)
+}
+
+// Purge is used to clear the cache
+func (c *ARCCache) Purge() {
+	c.t1.Purge()
+	c.t2.Purge()
+	c.b1.Purge()
+	c.b2.Purge()
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (c *ARCCache) Contains(key interface{}) bool {
+	return c.t1.Contains(key) || c.t2.Contains(key)
+}
+
+// Peek is used to inspect the cache value of a key
+// without updating recency or frequency.
+func (c *ARCCache) Peek(key interface{}) (interface{}, bool) {
+	if val, ok := c.t1.Peek(key); ok {
+		return val, ok
+	}
+	return c.t2.Peek(key)
+}

--- a/arc.go
+++ b/arc.go
@@ -114,8 +114,10 @@ func (c *ARCCache) Add(key, value interface{}) {
 			c.p += delta
 		}
 
-		// Make room in the cache
-		c.replace(key)
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(key)
+		}
 
 		// Remove from B1
 		c.b1.Remove(key)
@@ -141,8 +143,10 @@ func (c *ARCCache) Add(key, value interface{}) {
 			c.p -= delta
 		}
 
-		// Make room in the cache
-		c.replace(key)
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(key)
+		}
 
 		// Remove from B2
 		c.b2.Remove(key)

--- a/arc.go
+++ b/arc.go
@@ -122,7 +122,7 @@ func (c *ARCCache) Add(key, value interface{}) {
 
 		// Potentially need to make room in the cache
 		if c.t1.Len()+c.t2.Len() >= c.size {
-			c.replace(key)
+			c.replace(false)
 		}
 
 		// Remove from B1
@@ -151,7 +151,7 @@ func (c *ARCCache) Add(key, value interface{}) {
 
 		// Potentially need to make room in the cache
 		if c.t1.Len()+c.t2.Len() >= c.size {
-			c.replace(key)
+			c.replace(true)
 		}
 
 		// Remove from B2
@@ -170,7 +170,7 @@ func (c *ARCCache) Add(key, value interface{}) {
 			c.t1.RemoveOldest()
 		} else {
 			c.b1.RemoveOldest()
-			c.replace(key)
+			c.replace(false)
 		}
 	} else {
 		t2Len := c.t2.Len()
@@ -180,7 +180,7 @@ func (c *ARCCache) Add(key, value interface{}) {
 			if total == 2*c.size {
 				c.b2.RemoveOldest()
 			}
-			c.replace(key)
+			c.replace(false)
 		}
 	}
 
@@ -191,9 +191,9 @@ func (c *ARCCache) Add(key, value interface{}) {
 
 // replace is used to adaptively evict from either T1 or T2
 // based on the current learned value of P
-func (c *ARCCache) replace(key interface{}) {
+func (c *ARCCache) replace(b2ContainsKey bool) {
 	t1Len := c.t1.Len()
-	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && c.b2.Contains(key))) {
+	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
 		c.t1.RemoveOldest()
 	} else {
 		c.t2.RemoveOldest()

--- a/arc.go
+++ b/arc.go
@@ -10,7 +10,9 @@ import (
 // ARC is an enhancement over the standard LRU cache in that tracks both
 // frequency and recency of use. This avoids a burst in access to new
 // entries from evicting the frequently used older entries. It adds some
-// additional tracking overhead to a standard LRU cache.
+// additional tracking overhead to a standard LRU cache, computationally
+// it is roughly 2x the cost, and the extra memory overhead is linear
+// with the size of the cache.
 type ARCCache struct {
 	size int // Size is the total capacity of the cache
 	p    int // P is the dynamic preference towards T1 or T2

--- a/arc.go
+++ b/arc.go
@@ -63,8 +63,8 @@ func (c *ARCCache) Get(key interface{}) (interface{}, bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	// Check if the value is contained in T1 (recent), and potentially
-	// promote it to frequent T2
+	// Ff the value is contained in T1 (recent), then
+	// promote it to T2 (frequent)
 	if val, ok := c.t1.Peek(key); ok {
 		c.t1.Remove(key)
 		c.t2.Add(key, val)
@@ -72,8 +72,7 @@ func (c *ARCCache) Get(key interface{}) (interface{}, bool) {
 	}
 
 	// Check if the value is contained in T2 (frequent)
-	val, ok := c.t2.Get(key)
-	if ok {
+	if val, ok := c.t2.Get(key); ok {
 		return val, ok
 	}
 
@@ -100,7 +99,7 @@ func (c *ARCCache) Add(key, value interface{}) {
 		return
 	}
 
-	// Check if this value was recently evitcted as part of the
+	// Check if this value was recently evicted as part of the
 	// recently used list
 	if c.b1.Contains(key) {
 		// T1 set is too small, increase P appropriately
@@ -209,7 +208,7 @@ func (c *ARCCache) Keys() []interface{} {
 	return append(k1, k2...)
 }
 
-// Remove is used to perge a key from the cache
+// Remove is used to purge a key from the cache
 func (c *ARCCache) Remove(key interface{}) {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/arc_test.go
+++ b/arc_test.go
@@ -1,0 +1,96 @@
+package lru
+
+import "testing"
+
+func TestARC(t *testing.T) {
+	l, err := NewARC(128)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Get(192) // expect 192 to be last key in l.Keys()
+
+	for i, k := range l.Keys() {
+		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+			t.Fatalf("out of order key: %v", k)
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+// Test that Contains doesn't update recent-ness
+func TestARC_Contains(t *testing.T) {
+	l, err := NewARC(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// Test that Peek doesn't update recent-ness
+func TestARC_Peek(t *testing.T) {
+	l, err := NewARC(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}

--- a/arc_test.go
+++ b/arc_test.go
@@ -10,6 +10,67 @@ func init() {
 	rand.Seed(time.Now().Unix())
 }
 
+func BenchmarkARC_Rand(b *testing.B) {
+	l, err := NewARC(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		trace[i] = rand.Int63() % 32768
+	}
+
+	b.ResetTimer()
+
+	var hit, miss int
+	for i := 0; i < 2*b.N; i++ {
+		if i%2 == 0 {
+			l.Add(trace[i], trace[i])
+		} else {
+			_, ok := l.Get(trace[i])
+			if ok {
+				hit++
+			} else {
+				miss++
+			}
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkARC_Freq(b *testing.B) {
+	l, err := NewARC(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		if i%2 == 0 {
+			trace[i] = rand.Int63() % 16384
+		} else {
+			trace[i] = rand.Int63() % 32768
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Add(trace[i], trace[i])
+	}
+	var hit, miss int
+	for i := 0; i < b.N; i++ {
+		_, ok := l.Get(trace[i])
+		if ok {
+			hit++
+		} else {
+			miss++
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
 func TestARC_RandomOps(t *testing.T) {
 	size := 128
 	l, err := NewARC(128)

--- a/arc_test.go
+++ b/arc_test.go
@@ -1,6 +1,45 @@
 package lru
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+func TestARC_RandomOps(t *testing.T) {
+	size := 128
+	l, err := NewARC(128)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	n := 200000
+	for i := 0; i < n; i++ {
+		key := rand.Int63() % 512
+		r := rand.Int63()
+		switch r % 3 {
+		case 0:
+			l.Add(key, key)
+		case 1:
+			l.Get(key)
+		case 2:
+			l.Remove(key)
+		}
+
+		if l.t1.Len()+l.t2.Len() > size {
+			t.Fatalf("bad: t1: %d t2: %d b1: %d b2: %d p: %d",
+				l.t1.Len(), l.t2.Len(), l.b1.Len(), l.b2.Len(), l.p)
+		}
+		if l.b1.Len()+l.b2.Len() > size {
+			t.Fatalf("bad: t1: %d t2: %d b1: %d b2: %d p: %d",
+				l.t1.Len(), l.t2.Len(), l.b1.Len(), l.b2.Len(), l.p)
+		}
+	}
+}
 
 func TestARC(t *testing.T) {
 	l, err := NewARC(128)

--- a/arc_test.go
+++ b/arc_test.go
@@ -268,14 +268,6 @@ func TestARC(t *testing.T) {
 		}
 	}
 
-	l.Get(192) // expect 192 to be last key in l.Keys()
-
-	for i, k := range l.Keys() {
-		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
-			t.Fatalf("out of order key: %v", k)
-		}
-	}
-
 	l.Purge()
 	if l.Len() != 0 {
 		t.Fatalf("bad len: %v", l.Len())

--- a/internal/lru.go
+++ b/internal/lru.go
@@ -1,0 +1,144 @@
+package internal
+
+import (
+	"container/list"
+	"errors"
+)
+
+// EvictCallback is used to get a callback when a cache entry is evicted
+type EvictCallback func(key interface{}, value interface{})
+
+// LRU implements a non-thread safe fixed size LRU cache
+type LRU struct {
+	size      int
+	evictList *list.List
+	items     map[interface{}]*list.Element
+	onEvict   EvictCallback
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key   interface{}
+	value interface{}
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c := &LRU{
+		size:      size,
+		evictList: list.New(),
+		items:     make(map[interface{}]*list.Element, size),
+		onEvict:   onEvict,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache
+func (c *LRU) Purge() {
+	if c.onEvict != nil {
+		for k, v := range c.items {
+			c.onEvict(k, v.Value.(*entry).value)
+		}
+	}
+
+	c.evictList = list.New()
+	c.items = make(map[interface{}]*list.Element)
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occured.
+func (c *LRU) Add(key, value interface{}) bool {
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*entry).value = value
+		return false
+	}
+
+	// Add new item
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	evict := c.evictList.Len() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		return ent.Value.(*entry).value, true
+	}
+	return
+}
+
+// Check if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *LRU) Contains(key interface{}) (ok bool) {
+	_, ok = c.items[key]
+	return ok
+}
+
+// Returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		return ent.Value.(*entry).value, true
+	}
+	return nil, ok
+}
+
+// Remove removes the provided key from the cache.
+func (c *LRU) Remove(key interface{}) {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *LRU) RemoveOldest() {
+	c.removeOldest()
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *LRU) Keys() []interface{} {
+	keys := make([]interface{}, len(c.items))
+	ent := c.evictList.Back()
+	i := 0
+	for ent != nil {
+		keys[i] = ent.Value.(*entry).key
+		ent = ent.Prev()
+		i++
+	}
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *LRU) Len() int {
+	return c.evictList.Len()
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.items, kv.key)
+	if c.onEvict != nil {
+		c.onEvict(kv.key, kv.value)
+	}
+}

--- a/internal/lru.go
+++ b/internal/lru.go
@@ -30,7 +30,7 @@ func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
 	c := &LRU{
 		size:      size,
 		evictList: list.New(),
-		items:     make(map[interface{}]*list.Element, size),
+		items:     make(map[interface{}]*list.Element),
 		onEvict:   onEvict,
 	}
 	return c, nil
@@ -38,14 +38,13 @@ func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
 
 // Purge is used to completely clear the cache
 func (c *LRU) Purge() {
-	if c.onEvict != nil {
-		for k, v := range c.items {
+	for k, v := range c.items {
+		if c.onEvict != nil {
 			c.onEvict(k, v.Value.(*entry).value)
 		}
+		delete(c.items, k)
 	}
-
-	c.evictList = list.New()
-	c.items = make(map[interface{}]*list.Element)
+	c.evictList.Init()
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occured.

--- a/internal/lru.go
+++ b/internal/lru.go
@@ -106,6 +106,16 @@ func (c *LRU) RemoveOldest() {
 	c.removeOldest()
 }
 
+// GetOldest returns the oldest entry
+func (c *LRU) GetOldest() (interface{}, interface{}, bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
 // Keys returns a slice of the keys in the cache, from oldest to newest.
 func (c *LRU) Keys() []interface{} {
 	keys := make([]interface{}, len(c.items))

--- a/internal/lru.go
+++ b/internal/lru.go
@@ -125,11 +125,9 @@ func (c *LRU) GetOldest() (interface{}, interface{}, bool) {
 // Keys returns a slice of the keys in the cache, from oldest to newest.
 func (c *LRU) Keys() []interface{} {
 	keys := make([]interface{}, len(c.items))
-	ent := c.evictList.Back()
 	i := 0
-	for ent != nil {
+	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
 		keys[i] = ent.Value.(*entry).key
-		ent = ent.Prev()
 		i++
 	}
 	return keys

--- a/internal/lru.go
+++ b/internal/lru.go
@@ -102,8 +102,14 @@ func (c *LRU) Remove(key interface{}) {
 }
 
 // RemoveOldest removes the oldest item from the cache.
-func (c *LRU) RemoveOldest() {
-	c.removeOldest()
+func (c *LRU) RemoveOldest() (interface{}, interface{}, bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
 }
 
 // GetOldest returns the oldest entry

--- a/internal/lru.go
+++ b/internal/lru.go
@@ -94,11 +94,14 @@ func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
 	return nil, ok
 }
 
-// Remove removes the provided key from the cache.
-func (c *LRU) Remove(key interface{}) {
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU) Remove(key interface{}) bool {
 	if ent, ok := c.items[key]; ok {
 		c.removeElement(ent)
+		return true
 	}
+	return false
 }
 
 // RemoveOldest removes the oldest item from the cache.

--- a/internal/lru_test.go
+++ b/internal/lru_test.go
@@ -1,0 +1,127 @@
+package internal
+
+import "testing"
+
+func TestLRU(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+		}
+		evictCounter += 1
+	}
+	l, err := NewLRU(128, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	if evictCounter != 128 {
+		t.Fatalf("bad evict count: %v", evictCounter)
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Get(192) // expect 192 to be last key in l.Keys()
+
+	for i, k := range l.Keys() {
+		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+			t.Fatalf("out of order key: %v", k)
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+// Test that Add returns true/false if an eviction occured
+func TestLRU_Add(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		evictCounter += 1
+	}
+
+	l, err := NewLRU(1, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.Add(1, 1) == true || evictCounter != 0 {
+		t.Errorf("should not have an eviction")
+	}
+	if l.Add(2, 2) == false || evictCounter != 1 {
+		t.Errorf("should have an eviction")
+	}
+}
+
+// Test that Contains doesn't update recent-ness
+func TestLRU_Contains(t *testing.T) {
+	l, err := NewLRU(2, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// Test that Peek doesn't update recent-ness
+func TestLRU_Peek(t *testing.T) {
+	l, err := NewLRU(2, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}

--- a/internal/lru_test.go
+++ b/internal/lru_test.go
@@ -68,7 +68,7 @@ func TestLRU(t *testing.T) {
 	}
 }
 
-func TestLRU_GetOldest(t *testing.T) {
+func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 	l, err := NewLRU(128, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -81,6 +81,22 @@ func TestLRU_GetOldest(t *testing.T) {
 		t.Fatalf("missing")
 	}
 	if k.(int) != 128 {
+		t.Fatalf("bad: %v", k)
+	}
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != 128 {
+		t.Fatalf("bad: %v", k)
+	}
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != 129 {
 		t.Fatalf("bad: %v", k)
 	}
 }

--- a/internal/lru_test.go
+++ b/internal/lru_test.go
@@ -68,6 +68,23 @@ func TestLRU(t *testing.T) {
 	}
 }
 
+func TestLRU_GetOldest(t *testing.T) {
+	l, err := NewLRU(128, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	k, _, ok := l.GetOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != 128 {
+		t.Fatalf("bad: %v", k)
+	}
+}
+
 // Test that Add returns true/false if an eviction occured
 func TestLRU_Add(t *testing.T) {
 	evictCounter := 0

--- a/internal/lru_test.go
+++ b/internal/lru_test.go
@@ -44,8 +44,15 @@ func TestLRU(t *testing.T) {
 		}
 	}
 	for i := 128; i < 192; i++ {
-		l.Remove(i)
-		_, ok := l.Get(i)
+		ok := l.Remove(i)
+		if !ok {
+			t.Fatalf("should be contained")
+		}
+		ok = l.Remove(i)
+		if ok {
+			t.Fatalf("should not be contained")
+		}
+		_, ok = l.Get(i)
 		if ok {
 			t.Fatalf("should be deleted")
 		}

--- a/lru.go
+++ b/lru.go
@@ -4,24 +4,15 @@
 package lru
 
 import (
-	"container/list"
-	"errors"
 	"sync"
+
+	"github.com/hashicorp/golang-lru/internal"
 )
 
 // Cache is a thread-safe fixed size LRU cache.
 type Cache struct {
-	size      int
-	evictList *list.List
-	items     map[interface{}]*list.Element
-	lock      sync.RWMutex
-	onEvicted func(key interface{}, value interface{})
-}
-
-// entry is used to hold a value in the evictList
-type entry struct {
-	key   interface{}
-	value interface{}
+	lru  *internal.LRU
+	lock sync.RWMutex
 }
 
 // New creates an LRU of the given size
@@ -29,15 +20,15 @@ func New(size int) (*Cache, error) {
 	return NewWithEvict(size, nil)
 }
 
+// NewWithEvict constructs a fixed size cache with the given eviction
+// callback.
 func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) (*Cache, error) {
-	if size <= 0 {
-		return nil, errors.New("Must provide a positive size")
+	lru, err := internal.NewLRU(size, internal.EvictCallback(onEvicted))
+	if err != nil {
+		return nil, err
 	}
 	c := &Cache{
-		size:      size,
-		evictList: list.New(),
-		items:     make(map[interface{}]*list.Element),
-		onEvicted: onEvicted,
+		lru: lru,
 	}
 	return c, nil
 }
@@ -45,155 +36,79 @@ func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) 
 // Purge is used to completely clear the cache
 func (c *Cache) Purge() {
 	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	for k, v := range c.items {
-		if c.onEvicted != nil {
-			c.onEvicted(k, v.Value.(*entry).value)
-		}
-
-		delete(c.items, k)
-	}
-
-	c.evictList.Init()
+	c.lru.Purge()
+	c.lock.Unlock()
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occured.
 func (c *Cache) Add(key, value interface{}) bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	// Check for existing item
-	if ent, ok := c.items[key]; ok {
-		c.evictList.MoveToFront(ent)
-		ent.Value.(*entry).value = value
-		return false
-	}
-
-	// Add new item
-	ent := &entry{key, value}
-	entry := c.evictList.PushFront(ent)
-	c.items[key] = entry
-
-	evict := c.evictList.Len() > c.size
-	// Verify size not exceeded
-	if evict {
-		c.removeOldest()
-	}
-	return evict
+	return c.lru.Add(key, value)
 }
 
 // Get looks up a key's value from the cache.
-func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
+func (c *Cache) Get(key interface{}) (interface{}, bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	if ent, ok := c.items[key]; ok {
-		c.evictList.MoveToFront(ent)
-		return ent.Value.(*entry).value, true
-	}
-	return
+	return c.lru.Get(key)
 }
 
-// Check if a key is in the cache, without updating the recent-ness or deleting it for being stale.
-func (c *Cache) Contains(key interface{}) (ok bool) {
+// Check if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *Cache) Contains(key interface{}) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-
-	_, ok = c.items[key]
-	return ok
+	return c.lru.Contains(key)
 }
 
-// Returns the key value (or undefined if not found) without updating the "recently used"-ness of the key.
-// (If you find yourself using this a lot, you might be using the wrong sort of data structure, but there are some use cases where it's handy.)
-func (c *Cache) Peek(key interface{}) (value interface{}, ok bool) {
+// Returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *Cache) Peek(key interface{}) (interface{}, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-
-	if ent, ok := c.items[key]; ok {
-		return ent.Value.(*entry).value, true
-	}
-	return nil, ok
+	return c.lru.Peek(key)
 }
 
-// ContainsOrAdd checks if a key is in the cache (without updating the recent-ness or deleting it for being stale),
-// if not, adds the value. Returns whether found and whether an eviction occurred.
+// ContainsOrAdd checks if a key is in the cache  without updating the
+// recent-ness or deleting it for being stale,  and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
 func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evict bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	_, ok = c.items[key]
-	if ok {
+	if c.lru.Contains(key) {
 		return true, false
+	} else {
+		evict := c.lru.Add(key, value)
+		return false, evict
 	}
-
-	ent := &entry{key, value}
-	entry := c.evictList.PushFront(ent)
-	c.items[key] = entry
-
-	evict = c.evictList.Len() > c.size
-	// Verify size not exceeded
-	if evict {
-		c.removeOldest()
-	}
-	return false, evict
 }
 
 // Remove removes the provided key from the cache.
 func (c *Cache) Remove(key interface{}) {
 	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if ent, ok := c.items[key]; ok {
-		c.removeElement(ent)
-	}
+	c.lru.Remove(key)
+	c.lock.Unlock()
 }
 
 // RemoveOldest removes the oldest item from the cache.
 func (c *Cache) RemoveOldest() {
 	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.removeOldest()
+	c.lru.RemoveOldest()
+	c.lock.Unlock()
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
 func (c *Cache) Keys() []interface{} {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-
-	keys := make([]interface{}, len(c.items))
-	ent := c.evictList.Back()
-	i := 0
-	for ent != nil {
-		keys[i] = ent.Value.(*entry).key
-		ent = ent.Prev()
-		i++
-	}
-
-	return keys
+	return c.lru.Keys()
 }
 
 // Len returns the number of items in the cache.
 func (c *Cache) Len() int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.evictList.Len()
-}
-
-// removeOldest removes the oldest item from the cache.
-func (c *Cache) removeOldest() {
-	ent := c.evictList.Back()
-	if ent != nil {
-		c.removeElement(ent)
-	}
-}
-
-// removeElement is used to remove a given list element from the cache
-func (c *Cache) removeElement(e *list.Element) {
-	c.evictList.Remove(e)
-	kv := e.Value.(*entry)
-	delete(c.items, kv.key)
-	if c.onEvicted != nil {
-		c.onEvicted(kv.key, kv.value)
-	}
+	return c.lru.Len()
 }

--- a/lru_test.go
+++ b/lru_test.go
@@ -1,6 +1,70 @@
 package lru
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkLRU_Rand(b *testing.B) {
+	l, err := New(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		trace[i] = rand.Int63() % 32768
+	}
+
+	b.ResetTimer()
+
+	var hit, miss int
+	for i := 0; i < 2*b.N; i++ {
+		if i%2 == 0 {
+			l.Add(trace[i], trace[i])
+		} else {
+			_, ok := l.Get(trace[i])
+			if ok {
+				hit++
+			} else {
+				miss++
+			}
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkLRU_Freq(b *testing.B) {
+	l, err := New(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		if i%2 == 0 {
+			trace[i] = rand.Int63() % 16384
+		} else {
+			trace[i] = rand.Int63() % 32768
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Add(trace[i], trace[i])
+	}
+	var hit, miss int
+	for i := 0; i < b.N; i++ {
+		_, ok := l.Get(trace[i])
+		if ok {
+			hit++
+		} else {
+			miss++
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
 
 func TestLRU(t *testing.T) {
 	evictCounter := 0


### PR DESCRIPTION
Adds an ARCCache implementation, which adaptively trades off between storing frequently used and recently used entries. This is nice as a small burst in access to new records does not cause the frequently used records to be evicted. In almost all cases an ARC outperforms a standard LRU, but there is an additional overhead.

This PR moves the pure LRU logic into an `internal` package which is not thread safe. The existing LRUCache provides thread safety on top of that. The ARCCache implementation uses the same internal LRU, and is also thread safe.