### PR TITLE
Adds 2Q replacement algorithm implementation

### DIFF
--- a/2q.go
+++ b/2q.go
@@ -1,0 +1,212 @@
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/golang-lru/internal"
+)
+
+const (
+	// Default2QRecentRatio is the ratio of the 2Q cache dedicated
+	// to recently added entries that have only been accessed once.
+	Default2QRecentRatio = 0.25
+
+	// Default2QGhostEntries is the default ratio of ghost
+	// entries kept to track entries recently evicted
+	Default2QGhostEntries = 0.50
+)
+
+// TwoQueueCache is a thread-safe fixed size 2Q cache.
+// 2Q is an enhancement over the standard LRU cache
+// in that it tracks both frequently and recently used
+// entries seperately. This avoids a burst in access to new
+// entries from evicting frequently used entries. It adds some
+// additional tracking overhead to the standard LRU cache, and is
+// computationally about 2x the cost, and adds some metadata over
+// head. The ARCCache is similar, but does not require setting any
+// parameters.
+type TwoQueueCache struct {
+	size       int
+	recentSize int
+
+	recent      *internal.LRU
+	frequent    *internal.LRU
+	recentEvict *internal.LRU
+	lock        sync.RWMutex
+}
+
+// New2Q creates a new TwoQueueCache using the default
+// values for the parameters.
+func New2Q(size int) (*TwoQueueCache, error) {
+	return New2QParams(size, Default2QRecentRatio, Default2QGhostEntries)
+}
+
+// New2QParams creates a new TwoQueueCache using the provided
+// parameter values.
+func New2QParams(size int, recentRatio float64, ghostRatio float64) (*TwoQueueCache, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid size")
+	}
+	if recentRatio < 0.0 || recentRatio > 1.0 {
+		return nil, fmt.Errorf("invalid recent ratio")
+	}
+	if ghostRatio < 0.0 || ghostRatio > 1.0 {
+		return nil, fmt.Errorf("invalid ghost ratio")
+	}
+
+	// Determine the sub-sizes
+	recentSize := int(float64(size) * recentRatio)
+	evictSize := int(float64(size) * ghostRatio)
+
+	// Allocate the LRUs
+	recent, err := internal.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	frequent, err := internal.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	recentEvict, err := internal.NewLRU(evictSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the cache
+	c := &TwoQueueCache{
+		size:        size,
+		recentSize:  recentSize,
+		recent:      recent,
+		frequent:    frequent,
+		recentEvict: recentEvict,
+	}
+	return c, nil
+}
+
+func (c *TwoQueueCache) Get(key interface{}) (interface{}, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if this is a frequent value
+	if val, ok := c.frequent.Get(key); ok {
+		return val, ok
+	}
+
+	// If the value is contained in recent, then we
+	// promote it to frequent
+	if val, ok := c.recent.Peek(key); ok {
+		c.recent.Remove(key)
+		c.frequent.Add(key, val)
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+func (c *TwoQueueCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is frequently used already,
+	// and just update the value
+	if c.frequent.Contains(key) {
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Check if the value is recently used, and promote
+	// the value into the frequent list
+	if c.recent.Contains(key) {
+		c.recent.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// If the value was recently evicted, add it to the
+	// frequently used list
+	if c.recentEvict.Contains(key) {
+		c.ensureSpace(true)
+		c.recentEvict.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Add to the recently seen list
+	c.ensureSpace(false)
+	c.recent.Add(key, value)
+	return
+}
+
+// ensureSpace is used to ensure we have space in the cache
+func (c *TwoQueueCache) ensureSpace(recentEvict bool) {
+	// If we have space, nothing to do
+	recentLen := c.recent.Len()
+	freqLen := c.frequent.Len()
+	if recentLen+freqLen < c.size {
+		return
+	}
+
+	// If the recent buffer is larger than
+	// the target, evict from there
+	if recentLen > 0 && (recentLen > c.recentSize || (recentLen == c.recentSize && !recentEvict)) {
+		k, _, _ := c.recent.RemoveOldest()
+		c.recentEvict.Add(k, nil)
+		return
+	}
+
+	// Remove from the frequent list otherwise
+	c.frequent.RemoveOldest()
+}
+
+func (c *TwoQueueCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.recent.Len() + c.frequent.Len()
+}
+
+func (c *TwoQueueCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.frequent.Keys()
+	k2 := c.recent.Keys()
+	return append(k1, k2...)
+}
+
+func (c *TwoQueueCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.frequent.Remove(key) {
+		return
+	}
+	if c.recent.Remove(key) {
+		return
+	}
+	if c.recentEvict.Remove(key) {
+		return
+	}
+}
+
+func (c *TwoQueueCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.recent.Purge()
+	c.frequent.Purge()
+	c.recentEvict.Purge()
+}
+
+func (c *TwoQueueCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.frequent.Contains(key) || c.recent.Contains(key)
+}
+
+func (c *TwoQueueCache) Peek(key interface{}) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.frequent.Peek(key); ok {
+		return val, ok
+	}
+	return c.recent.Peek(key)
+}

--- a/2q_test.go
+++ b/2q_test.go
@@ -1,0 +1,306 @@
+package lru
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func Benchmark2Q_Rand(b *testing.B) {
+	l, err := New2Q(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		trace[i] = rand.Int63() % 32768
+	}
+
+	b.ResetTimer()
+
+	var hit, miss int
+	for i := 0; i < 2*b.N; i++ {
+		if i%2 == 0 {
+			l.Add(trace[i], trace[i])
+		} else {
+			_, ok := l.Get(trace[i])
+			if ok {
+				hit++
+			} else {
+				miss++
+			}
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func Benchmark2Q_Freq(b *testing.B) {
+	l, err := New2Q(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		if i%2 == 0 {
+			trace[i] = rand.Int63() % 16384
+		} else {
+			trace[i] = rand.Int63() % 32768
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Add(trace[i], trace[i])
+	}
+	var hit, miss int
+	for i := 0; i < b.N; i++ {
+		_, ok := l.Get(trace[i])
+		if ok {
+			hit++
+		} else {
+			miss++
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func Test2Q_RandomOps(t *testing.T) {
+	size := 128
+	l, err := New2Q(128)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	n := 200000
+	for i := 0; i < n; i++ {
+		key := rand.Int63() % 512
+		r := rand.Int63()
+		switch r % 3 {
+		case 0:
+			l.Add(key, key)
+		case 1:
+			l.Get(key)
+		case 2:
+			l.Remove(key)
+		}
+
+		if l.recent.Len()+l.frequent.Len() > size {
+			t.Fatalf("bad: recent: %d freq: %d",
+				l.recent.Len(), l.frequent.Len())
+		}
+	}
+}
+
+func Test2Q_Get_RecentToFrequent(t *testing.T) {
+	l, err := New2Q(128)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Touch all the entries, should be in t1
+	for i := 0; i < 128; i++ {
+		l.Add(i, i)
+	}
+	if n := l.recent.Len(); n != 128 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 0 {
+		t.Fatalf("bad: %d", n)
+	}
+
+	// Get should upgrade to t2
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("missing: %d", i)
+		}
+	}
+	if n := l.recent.Len(); n != 0 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 128 {
+		t.Fatalf("bad: %d", n)
+	}
+
+	// Get be from t2
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("missing: %d", i)
+		}
+	}
+	if n := l.recent.Len(); n != 0 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 128 {
+		t.Fatalf("bad: %d", n)
+	}
+}
+
+func Test2Q_Add_RecentToFrequent(t *testing.T) {
+	l, err := New2Q(128)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Add initially to recent
+	l.Add(1, 1)
+	if n := l.recent.Len(); n != 1 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 0 {
+		t.Fatalf("bad: %d", n)
+	}
+
+	// Add should upgrade to frequent
+	l.Add(1, 1)
+	if n := l.recent.Len(); n != 0 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 1 {
+		t.Fatalf("bad: %d", n)
+	}
+
+	// Add should remain in frequent
+	l.Add(1, 1)
+	if n := l.recent.Len(); n != 0 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 1 {
+		t.Fatalf("bad: %d", n)
+	}
+}
+
+func Test2Q_Add_RecentEvict(t *testing.T) {
+	l, err := New2Q(4)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Add 1,2,3,4,5 -> Evict 1
+	l.Add(1, 1)
+	l.Add(2, 2)
+	l.Add(3, 3)
+	l.Add(4, 4)
+	l.Add(5, 5)
+	if n := l.recent.Len(); n != 4 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.recentEvict.Len(); n != 1 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 0 {
+		t.Fatalf("bad: %d", n)
+	}
+
+	// Pull in the recently evicted
+	l.Add(1, 1)
+	if n := l.recent.Len(); n != 3 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.recentEvict.Len(); n != 1 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 1 {
+		t.Fatalf("bad: %d", n)
+	}
+
+	// Add 6, should cause another recent evict
+	l.Add(6, 6)
+	if n := l.recent.Len(); n != 3 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.recentEvict.Len(); n != 2 {
+		t.Fatalf("bad: %d", n)
+	}
+	if n := l.frequent.Len(); n != 1 {
+		t.Fatalf("bad: %d", n)
+	}
+}
+
+func Test2Q(t *testing.T) {
+	l, err := New2Q(128)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+// Test that Contains doesn't update recent-ness
+func Test2Q_Contains(t *testing.T) {
+	l, err := New2Q(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// Test that Peek doesn't update recent-ness
+func Test2Q_Peek(t *testing.T) {
+	l, err := New2Q(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}

--- a/arc.go
+++ b/arc.go
@@ -12,7 +12,8 @@ import (
 // entries from evicting the frequently used older entries. It adds some
 // additional tracking overhead to a standard LRU cache, computationally
 // it is roughly 2x the cost, and the extra memory overhead is linear
-// with the size of the cache.
+// with the size of the cache. ARC has been patented by IBM, but is
+// similar to the TwoQueueCache (2Q) which requires setting parameters.
 type ARCCache struct {
 	size int // Size is the total capacity of the cache
 	p    int // P is the dynamic preference towards T1 or T2


### PR DESCRIPTION
This PR implements the 2Q cache replacement algorithm (http://www.vldb.org/conf/1994/P439.PDF), and documents the IBM patent on the ARC cache. The 2Q cache is not patent encumbered, but unlike ARC requires tuning of parameters.