### PR TITLE
[lru_ttl] add TTL functionality to our LRU cache

### DIFF
--- a/lru_ttl.go
+++ b/lru_ttl.go
@@ -1,0 +1,49 @@
+package lru
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type LruWithTTL struct {
+	Cache
+	schedule       map[interface{}]bool
+	schedule_mutex sync.Mutex
+}
+
+// New creates an LRU of the given size
+func NewTTL(size int) (*LruWithTTL, error) {
+	return NewTTLWithEvict(size, nil)
+}
+
+func NewTTLWithEvict(size int, onEvicted func(key interface{}, value interface{})) (*LruWithTTL, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c, _ := NewWithEvict(size, onEvicted)
+	return &LruWithTTL{*c, make(map[interface{}]bool), sync.Mutex{}}, nil
+}
+
+func (this *LruWithTTL) clearSchedule(key interface{}) {
+	this.schedule_mutex.Lock()
+	defer this.schedule_mutex.Unlock()
+	delete(this.schedule, key)
+}
+
+func (this *LruWithTTL) AddWithTTL(key, value interface{}, ttl time.Duration) bool {
+	this.schedule_mutex.Lock()
+	defer this.schedule_mutex.Unlock()
+	if this.schedule[key] {
+		// already scheduled, nothing to do
+	} else {
+		this.schedule[key] = true
+		// Schedule cleanup
+		go func() {
+			defer this.Cache.Remove(key)
+			defer this.clearSchedule(key)
+			time.Sleep(ttl)
+		}()
+	}
+	return this.Cache.Add(key, value)
+}

--- a/lru_ttl_test.go
+++ b/lru_ttl_test.go
@@ -1,0 +1,56 @@
+package lru
+
+import (
+	"testing"
+	"time"
+)
+
+// test that Add returns true/false if an eviction occurred
+func TestLRUTTLAddNoTTL(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		evictCounter += 1
+	}
+
+	l, err := NewTTLWithEvict(1, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.Add(1, 1) == true || evictCounter != 0 {
+		t.Errorf("should not have an eviction")
+	}
+	if l.Add(2, 2) == false || evictCounter != 1 {
+		t.Errorf("should have an eviction")
+	}
+}
+
+// test that Add returns true/false if an eviction occurred
+func TestLRUTTLAddWithTTL(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		evictCounter += 1
+		if v.(int) != evictCounter {
+			t.Errorf("Eviction happened out of order. Got %v, expected %v", v.(int), evictCounter)
+		}
+	}
+
+	l, err := NewTTLWithEvict(2, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.AddWithTTL(1, 1, time.Millisecond*5) == true {
+		t.Errorf("should not have an eviction")
+	}
+	if l.AddWithTTL(2, 2, time.Millisecond*10) == true {
+		t.Errorf("should have an eviction")
+	}
+
+	// Wait for TTLs to expire
+	time.Sleep(25 * time.Millisecond)
+
+	if evictCounter != 2 {
+		t.Errorf("should have been 2 evictions")
+	}
+}


### PR DESCRIPTION
We've been using this addition for a number of months with great success.

Basically, we have a stream of events we want to de-duplicate and merge, but we also want to guarantee that popular events eventually get flushed to storage periodically. This is pretty straight forward to do by adding a ~5 second TTL and calling a save method in the on_evict hook. Naturally this means we do one update per event group every N seconds rather than every requests, saving our DB significant load.

I can imagine other use cases too, such as ensuring your local cache is never too out of date when being used as a look aside cache. Edit: Our other use case is caching authentication information for the lifetime of the token by building a token -> user map. Naturally, we want this information to expire in a timely fashion :)

For more details on our particular use case:
https://blogs.unity3d.com/2015/12/02/the-state-of-game-performance-reporting/
