### PR TITLE
Implement LRU cache with TTL

### DIFF
--- a/lru_ttl.go
+++ b/lru_ttl.go
@@ -1,0 +1,170 @@
+package lru
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// NOTE: this implementation will ensure that the cache will become eventually consistent.
+// Expired items will stay in the cache until it is removed.
+//
+// When a GET is received on the expired item, the item is removed as part of the GET
+// call. But, the other functions would still include the expired item in their result until
+// it is removed by the cleanup routine.
+//
+// `Add` is the only call which will update the lastAccessTime of an item.
+
+// CacheWithTTL implements thread safe fixed size LRU cache with TTL
+type CacheWithTTL struct {
+	*simplelru.LRU
+	lock sync.RWMutex
+	TTL  time.Duration
+}
+
+// cacheValue is a wrapper around the cache value to hold last accessed time
+type cacheValue struct {
+	value          interface{}
+	lastAccessTime time.Time
+}
+
+// NewTTL constructs an LRU of the given size with the given TTL
+func NewTTL(size int, ttl time.Duration) (simplelru.LRUCache, error) {
+	return NewTTLWithEvict(size, ttl, nil)
+}
+
+// NewTTLWithEvict constructs an LRU of the given size with given TTL
+// Also, sets up the evict function
+func NewTTLWithEvict(size int, ttl time.Duration, onEvict simplelru.EvictCallback) (simplelru.LRUCache, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+
+	lru, err := simplelru.NewLRU(size,
+		func(k interface{}, v interface{}) {
+			if onEvict != nil {
+				onEvict(k, v.(cacheValue).value)
+			}
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lruWithTTL := &CacheWithTTL{LRU: lru, TTL: ttl}
+
+	// clean expired items
+	go lruWithTTL.cleanup()
+
+	return lruWithTTL, nil
+}
+
+// Add adds the item to the cache. It also includes the `lastAccessTime` to the value.
+// Life of an item can be increased by calling `Add` multiple times on the same key.
+func (c *CacheWithTTL) Add(key, value interface{}) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.LRU.Add(key,
+		cacheValue{
+			value:          value,
+			lastAccessTime: time.Now(),
+		})
+}
+
+// Get looks up a key's value from the cache.
+// Also, it unmarshals `lastAccessTime` from `Get` response
+func (c *CacheWithTTL) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	val, ok := c.LRU.Get(key)
+	// while the cleanup routine is catching will the other items, remove the item
+	// if someone tries to access it through this GET call.
+	if ok {
+		if time.Now().After(val.(cacheValue).lastAccessTime.Add(c.TTL)) {
+			c.LRU.Remove(key)
+		} else {
+			return val.(cacheValue).value, ok
+		}
+	}
+
+	return nil, false
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+// Also, it unmarshals the `lastAccessTime` from the result
+func (c *CacheWithTTL) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	val, ok := c.LRU.Peek(key)
+	if ok {
+		return val.(cacheValue).value, ok
+	}
+	return val, ok
+}
+
+// Contains checks if a key is in the cache, without updating the
+// recent-ness or deleting it for being stale.
+func (c *CacheWithTTL) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.LRU.Contains(key)
+}
+
+// Purge is used to completely clear the cache.
+func (c *CacheWithTTL) Purge() {
+	c.lock.Lock()
+	c.LRU.Purge()
+	c.lock.Unlock()
+}
+
+// Remove removes the provided key from the cache.
+func (c *CacheWithTTL) Remove(key interface{}) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.LRU.Remove(key)
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *CacheWithTTL) RemoveOldest() (key interface{}, value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.LRU.RemoveOldest()
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *CacheWithTTL) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.LRU.Keys()
+}
+
+// Len returns the number of items in the cache.
+func (c *CacheWithTTL) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.LRU.Len()
+}
+
+// cleanup deletes all the expired items
+func (c *CacheWithTTL) cleanup() {
+	ticker := time.NewTicker(2 * time.Millisecond)
+
+	for {
+		select {
+		case <-ticker.C:
+			for _, key := range c.Keys() {
+				c.lock.Lock()
+				val, ok := c.LRU.Get(key)
+				c.lock.Unlock()
+
+				if ok && time.Now().After(val.(cacheValue).lastAccessTime.Add(c.TTL)) {
+					c.Remove(key)
+				}
+			}
+		}
+	}
+}

--- a/lru_ttl_test.go
+++ b/lru_ttl_test.go
@@ -1,0 +1,109 @@
+package lru
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/golang-lru/testutils"
+)
+
+func TestLRUWithTTL(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+		}
+		evictCounter++
+	}
+
+	l, err := NewTTLWithEvict(128, 1*time.Millisecond, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// test the LRU basic functions
+	testutils.BasicTest(t, l, 128, &evictCounter)
+
+	l.Purge()
+
+	// test TTL
+	evictCounter = 0
+	for i := 0; i < 128; i++ {
+		l.Add(i, i)
+
+		// make the items are evicted once TTL is met
+		time.Sleep(5 * time.Millisecond)
+
+		if l.Contains(i) {
+			t.Fatalf("item should have been evicted as TTL is met: %v", i)
+		}
+	}
+
+	// create a new cache with large capacity
+	evictCounter = 0
+	l, err = NewTTLWithEvict(20000, 1*time.Millisecond, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 20000; i++ {
+		l.Add(i, i)
+
+		// make the items are evicted once TTL is met
+		time.Sleep(5 * time.Millisecond)
+
+		if _, ok := l.Get(i); ok {
+			t.Fatalf("item should have been evicted as TTL is met: %v", i)
+		}
+	}
+
+	// all the items should have been evicted
+	cacheLen := l.Len()
+	if cacheLen > 0 {
+		t.Fatalf("bad len, expected: 0, got: %v", cacheLen)
+	}
+}
+
+func TestLRUWithTTLGetOldestRemoveOldest(t *testing.T) {
+	l, err := NewTTL(256, 1*time.Second)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	testutils.GetOldestRemoveOldestTest(t, l, 256)
+}
+
+// Test that Add returns true/false if an eviction occurred
+func TestLRUWithTTLAdd(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		evictCounter++
+	}
+
+	l, err := NewTTLWithEvict(1, 1*time.Second, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	testutils.AddTest(t, l, 1, &evictCounter)
+}
+
+// Test that Contains doesn't update recent-ness
+func TestLRUWithTTLContains(t *testing.T) {
+	l, err := NewTTL(2, 1*time.Second)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	testutils.ContainsTest(t, l, 2)
+}
+
+// TestLRUWithTTLPeek that Peek doesn't update recent-ness
+func TestLRUWithTTLPeek(t *testing.T) {
+	l, err := NewTTL(2, 1*time.Second)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	testutils.PeekTest(t, l, 2)
+}

--- a/testutils/lruutils.go
+++ b/testutils/lruutils.go
@@ -1,0 +1,163 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+func BasicTest(t *testing.T, l simplelru.LRUCache, capacity int, evictCounter *int) {
+	// add twice as much the capacity to check if eviction occurs
+	for i := 0; i < 2*capacity; i++ {
+		l.Add(i, i)
+	}
+
+	if l.Len() != capacity {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	// half of them should be evicted to make room for the incoming ones
+	if *evictCounter != capacity {
+		t.Fatalf("bad evict count: %v", evictCounter)
+	}
+
+	// cache should contain only the keys from capacity..2*capacity, anything before
+	// that should have been evicted
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+capacity {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+
+	for i := 0; i < capacity; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+
+	for i := capacity; i < 2*capacity; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+
+	// delete half the items from cache
+	lastIndex := (capacity + capacity/2)
+	for i := capacity; i < lastIndex; i++ {
+		ok := l.Remove(i)
+		if !ok {
+			t.Fatalf("should be contained")
+		}
+		ok = l.Remove(i)
+		if ok {
+			t.Fatalf("should not be contained")
+		}
+		_, ok = l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	// this makes this item the most recently accessed; moved to the front
+	l.Get(lastIndex) // expect 192 to be last key in l.Keys()
+
+	// make sure the cache has only half the capacity as we deleted half of them.
+	cacheLen := l.Len()
+	if capacity/2 != cacheLen {
+		t.Fatalf("invalid len. expected %v, got %v", capacity/2, cacheLen)
+	}
+
+	// Keys - returns items from oldest to newest.
+	for i, k := range l.Keys() {
+		// last item should be `lastIndex` and make sure the other items are ordered
+		if (i == cacheLen-1 && k != lastIndex) || (i < cacheLen-1 && k != i+lastIndex+1) {
+			t.Fatalf("out of order key: %v %v %v", i, k, cacheLen-1)
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	// try to get the random item
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+func GetOldestRemoveOldestTest(t *testing.T, l simplelru.LRUCache, capacity int) {
+	// add twice as much the capacity
+	for i := 0; i < 2*capacity; i++ {
+		l.Add(i, i)
+	}
+
+	k, _, ok := l.GetOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != capacity {
+		t.Fatalf("bad: %v", k)
+	}
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != capacity {
+		t.Fatalf("bad: %v", k)
+	}
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != capacity+1 {
+		t.Fatalf("bad: %v", k)
+	}
+}
+
+func AddTest(t *testing.T, l simplelru.LRUCache, capacity int, evictCounter *int) {
+	for i := 0; i < capacity; i++ {
+		if l.Add(i, i) == true || *evictCounter != 0 {
+			t.Errorf("should not have an eviction")
+		}
+	}
+	if l.Add(capacity, capacity) == false || *evictCounter != 1 {
+		t.Errorf("should have an eviction")
+	}
+}
+
+func ContainsTest(t *testing.T, l simplelru.LRUCache, capacity int) {
+	for i := 0; i < capacity; i++ {
+		l.Add(i, i)
+	}
+
+	// contains should not update the recent-ness so this item will remain the oldest
+	if !l.Contains(0) {
+		t.Errorf("0 should be contained")
+	}
+
+	// oldest (0) should have been evicted
+	l.Add(capacity, capacity)
+	if l.Contains(0) {
+		t.Errorf("Contains should not have updated recent-ness of 0")
+	}
+}
+
+func PeekTest(t *testing.T, l simplelru.LRUCache, capacity int) {
+	for i := 0; i < capacity; i++ {
+		l.Add(i, i)
+	}
+
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(capacity, capacity)
+	if l.Contains(0) {
+		t.Errorf("should have been removed to make room for the new item")
+	}
+}


### PR DESCRIPTION
This implements LRU with TTL:

1. Each item is added with `lastAccessedTime` which is used to remove the items once it meets TTL.

2. This ensures eventual consistency. Some items may continue to exists until the cleanup routine or GET call cleans it up. Please note that other calls `Contains`, `Peek`, `Len`, etc. will continue to include the expired item in their result unless otherwise it is removed by either GET or cleanup routine.

3. Cleanup on the GET ensures that the user never access the expired item.

Follow up:
- Move the interface from simple LRU to the top level and make sure lru.go and lru_ttl.go implements the interface. Now, that TTL is at the outer level, interface is not required in simplelru.
- Use the testutils in lru_test.go

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>