### PR TITLE
mutate functionality

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -108,3 +108,16 @@ func (c *Cache) Len() int {
 	defer c.lock.RUnlock()
 	return c.lru.Len()
 }
+
+// Mutate executes a callback function on the previous value of the key.
+// The mutator returns the new value for that key and an error.
+// If an error is returned from the mutator, the value returned from the mutator is thrown out and the key retains its original value.
+func (c *Cache) Mutate(key interface{}, mutator func(old interface{}, exists bool) (interface{}, error)) (bool, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	n, err := mutator(c.lru.Get(key))
+	if err != nil {
+		return false, err
+	}
+	return c.lru.Add(key, n), nil
+}


### PR DESCRIPTION
We're storing counts in our cache and want to increment numbers transactionally. We could use our own lock around the whole cache, but it seems more natural to do it in here.