### PR TITLE
Add autotest, badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+script:
+  - go test -v -covermode=count -coverprofile=coverage.out ./...
+
+after_script:
+  # Install and upload test coverage must not failure for test build
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![GoDoc](https://godoc.org/github.com/yudai/gojsondiff?status.svg)](http://godoc.org/github.com/hashicorp/golang-lru)
 [![Build Status](https://travis-ci.org/hashicorp/golang-lru.svg?branch=master)](https://travis-ci.org/hashicorp/golang-lru)
 [![Coverage Status](https://coveralls.io/repos/github/hashicorp/golang-lru/badge.svg?branch=master)](https://coveralls.io/github/hashicorp/golang-lru?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/hashicorp/golang-lru.svg?branch=master)](https://travis-ci.org/hashicorp/golang-lru)
+[![Coverage Status](https://coveralls.io/repos/github/hashicorp/golang-lru/badge.svg?branch=master)](https://coveralls.io/github/hashicorp/golang-lru?branch=master)
+
 golang-lru
 ==========
 


### PR DESCRIPTION
Suggest add travis autotests and badges: godoc, build status, code test covarage.

For work travis need to enable it for repo on travis.com

For code coverage need enable it on coveralls.io, get token and set it in travis settings