### PR TITLE
lru.Get(): avoid nil pointer dereference

### DIFF
--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -73,6 +73,9 @@ func (c *LRU) Add(key, value interface{}) (evicted bool) {
 func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
+		if ent.Value.(*entry) == nil {
+			return nil, false
+		}
 		return ent.Value.(*entry).value, true
 	}
 	return


### PR DESCRIPTION
Return failure rather than crash when nil value is inserted as lru data.