### PR TITLE
Fix confusing error msg. during 2Q creation

### DIFF
--- a/2q.go
+++ b/2q.go
@@ -70,7 +70,7 @@ func New2QParams(size int, recentRatio float64, ghostRatio float64) (*TwoQueueCa
 	}
 	recentEvict, err := simplelru.NewLRU(evictSize, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to create Evict cache, please choose a higher 'ghostRatio' or increase cache 'size'")
 	}
 
 	// Initialize the cache


### PR DESCRIPTION
For cases where the combination of 2Q size and ghostRatio result in
evict cache of size 0, the error message displayed to the user is
rather confusing.

This commit proposes to fix the code and give a suitable error message
to the user.

Addresses: Issue #51 