### PR TITLE
defer Unlock() right after Lock() when possible

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -33,23 +33,23 @@ func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) 
 // Purge is used to completely clear the cache.
 func (c *Cache) Purge() {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.lru.Purge()
-	c.lock.Unlock()
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occurred.
 func (c *Cache) Add(key, value interface{}) (evicted bool) {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	evicted = c.lru.Add(key, value)
-	c.lock.Unlock()
 	return evicted
 }
 
 // Get looks up a key's value from the cache.
 func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	value, ok = c.lru.Get(key)
-	c.lock.Unlock()
 	return value, ok
 }
 
@@ -57,8 +57,8 @@ func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
 // recent-ness or deleting it for being stale.
 func (c *Cache) Contains(key interface{}) bool {
 	c.lock.RLock()
+	defer c.lock.RUnlock()
 	containKey := c.lru.Contains(key)
-	c.lock.RUnlock()
 	return containKey
 }
 
@@ -66,8 +66,8 @@ func (c *Cache) Contains(key interface{}) bool {
 // the "recently used"-ness of the key.
 func (c *Cache) Peek(key interface{}) (value interface{}, ok bool) {
 	c.lock.RLock()
+	defer c.lock.RUnlock()
 	value, ok = c.lru.Peek(key)
-	c.lock.RUnlock()
 	return value, ok
 }
 
@@ -88,47 +88,47 @@ func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evicted bool) {
 // Remove removes the provided key from the cache.
 func (c *Cache) Remove(key interface{}) (present bool) {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	present = c.lru.Remove(key)
-	c.lock.Unlock()
 	return
 }
 
 // Resize changes the cache size.
 func (c *Cache) Resize(size int) (evicted int) {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	evicted = c.lru.Resize(size)
-	c.lock.Unlock()
 	return evicted
 }
 
 // RemoveOldest removes the oldest item from the cache.
 func (c *Cache) RemoveOldest() (key interface{}, value interface{}, ok bool) {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	key, value, ok = c.lru.RemoveOldest()
-	c.lock.Unlock()
 	return
 }
 
 // GetOldest returns the oldest entry
 func (c *Cache) GetOldest() (key interface{}, value interface{}, ok bool) {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	key, value, ok = c.lru.GetOldest()
-	c.lock.Unlock()
 	return
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
 func (c *Cache) Keys() []interface{} {
 	c.lock.RLock()
+	defer c.lock.RUnlock()
 	keys := c.lru.Keys()
-	c.lock.RUnlock()
 	return keys
 }
 
 // Len returns the number of items in the cache.
 func (c *Cache) Len() int {
 	c.lock.RLock()
+	defer c.lock.RUnlock()
 	length := c.lru.Len()
-	c.lock.RUnlock()
 	return length
 }


### PR DESCRIPTION
A simple refactor to adhere to established best practices.