### PR TITLE
Add expirable LRU implementation

### DIFF
--- a/simplelru/expirable_lru.go
+++ b/simplelru/expirable_lru.go
@@ -1,0 +1,276 @@
+package simplelru
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// ExpirableLRU implements a thread safe LRU with expirable entries.
+type ExpirableLRU struct {
+	size       int
+	purgeEvery time.Duration
+	ttl        time.Duration
+	done       chan struct{}
+	onEvicted  EvictCallback
+
+	sync.Mutex
+	items     map[interface{}]*list.Element
+	evictList *list.List
+}
+
+// noEvictionTTL - very long ttl to prevent eviction
+const noEvictionTTL = time.Hour * 24 * 365 * 10
+
+// NewExpirableLRU returns a new cache with expirable entries.
+//
+// Size parameter set to 0 makes cache of unlimited size.
+//
+// Providing 0 TTL turns expiring off.
+//
+// Activates deleteExpired by purgeEvery duration.
+// If MaxKeys and TTL are defined and PurgeEvery is zero, PurgeEvery will be set to 5 minutes.
+func NewExpirableLRU(size int, onEvict EvictCallback, ttl, purgeEvery time.Duration) *ExpirableLRU {
+	if size < 0 {
+		size = 0
+	}
+	if ttl <= 0 {
+		ttl = noEvictionTTL
+	}
+
+	res := ExpirableLRU{
+		items:      map[interface{}]*list.Element{},
+		evictList:  list.New(),
+		ttl:        ttl,
+		purgeEvery: purgeEvery,
+		size:       size,
+		onEvicted:  onEvict,
+		done:       make(chan struct{}),
+	}
+
+	// enable deleteExpired() running in separate goroutine for cache
+	// with non-zero TTL and size defined
+	if res.ttl != noEvictionTTL && (res.size > 0 || res.purgeEvery > 0) {
+		if res.purgeEvery <= 0 {
+			res.purgeEvery = time.Minute * 5 // non-zero purge enforced because size defined
+		}
+		go func(done <-chan struct{}) {
+			ticker := time.NewTicker(res.purgeEvery)
+			for {
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+					res.Lock()
+					res.deleteExpired()
+					res.Unlock()
+				}
+			}
+		}(res.done)
+	}
+	return &res
+}
+
+// Add key
+func (c *ExpirableLRU) Add(key, value interface{}) (evicted bool) {
+	c.Lock()
+	defer c.Unlock()
+	now := time.Now()
+
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*expirableEntry).value = value
+		ent.Value.(*expirableEntry).expiresAt = now.Add(c.ttl)
+		return false
+	}
+
+	// Add new item
+	ent := &expirableEntry{key: key, value: value, expiresAt: now.Add(c.ttl)}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	// Verify size not exceeded
+	if c.size > 0 && len(c.items) > c.size {
+		c.removeOldest()
+		return true
+	}
+	return false
+}
+
+// Get returns the key value
+func (c *ExpirableLRU) Get(key interface{}) (interface{}, bool) {
+	c.Lock()
+	defer c.Unlock()
+	if ent, ok := c.items[key]; ok {
+		// Expired item check
+		if time.Now().After(ent.Value.(*expirableEntry).expiresAt) {
+			return nil, false
+		}
+		c.evictList.MoveToFront(ent)
+		return ent.Value.(*expirableEntry).value, true
+	}
+	return nil, false
+}
+
+// Peek returns the key value (or undefined if not found) without updating the "recently used"-ness of the key.
+func (c *ExpirableLRU) Peek(key interface{}) (interface{}, bool) {
+	c.Lock()
+	defer c.Unlock()
+	if ent, ok := c.items[key]; ok {
+		// Expired item check
+		if time.Now().After(ent.Value.(*expirableEntry).expiresAt) {
+			return nil, false
+		}
+		return ent.Value.(*expirableEntry).value, true
+	}
+	return nil, false
+}
+
+// GetOldest returns the oldest entry
+func (c *ExpirableLRU) GetOldest() (key, value interface{}, ok bool) {
+	c.Lock()
+	defer c.Unlock()
+	ent := c.evictList.Back()
+	if ent != nil {
+		kv := ent.Value.(*expirableEntry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// Contains checks if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *ExpirableLRU) Contains(key interface{}) (ok bool) {
+	c.Lock()
+	defer c.Unlock()
+	_, ok = c.items[key]
+	return ok
+}
+
+// Remove key from the cache
+func (c *ExpirableLRU) Remove(key interface{}) bool {
+	c.Lock()
+	defer c.Unlock()
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *ExpirableLRU) RemoveOldest() (key, value interface{}, ok bool) {
+	c.Lock()
+	defer c.Unlock()
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+		kv := ent.Value.(*expirableEntry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *ExpirableLRU) Keys() []interface{} {
+	c.Lock()
+	defer c.Unlock()
+	return c.keys()
+}
+
+// Purge clears the cache completely.
+func (c *ExpirableLRU) Purge() {
+	c.Lock()
+	defer c.Unlock()
+	for k, v := range c.items {
+		if c.onEvicted != nil {
+			c.onEvicted(k, v.Value.(*expirableEntry).value)
+		}
+		delete(c.items, k)
+	}
+	c.evictList.Init()
+}
+
+// DeleteExpired clears cache of expired items
+func (c *ExpirableLRU) DeleteExpired() {
+	c.Lock()
+	defer c.Unlock()
+	c.deleteExpired()
+}
+
+// Len return count of items in cache
+func (c *ExpirableLRU) Len() int {
+	c.Lock()
+	defer c.Unlock()
+	return c.evictList.Len()
+}
+
+// Resize changes the cache size. size 0 doesn't resize the cache, as it means unlimited.
+func (c *ExpirableLRU) Resize(size int) (evicted int) {
+	if size <= 0 {
+		return 0
+	}
+	c.Lock()
+	defer c.Unlock()
+	diff := c.evictList.Len() - size
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		c.removeOldest()
+	}
+	c.size = size
+	return diff
+}
+
+// Close cleans the cache and destroys running goroutines
+func (c *ExpirableLRU) Close() {
+	c.Lock()
+	defer c.Unlock()
+	close(c.done)
+}
+
+// removeOldest removes the oldest item from the cache. Has to be called with lock!
+func (c *ExpirableLRU) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest. Has to be called with lock!
+func (c *ExpirableLRU) keys() []interface{} {
+	keys := make([]interface{}, 0, len(c.items))
+	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
+		keys = append(keys, ent.Value.(*expirableEntry).key)
+	}
+	return keys
+}
+
+// removeElement is used to remove a given list element from the cache. Has to be called with lock!
+func (c *ExpirableLRU) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*expirableEntry)
+	delete(c.items, kv.key)
+	if c.onEvicted != nil {
+		c.onEvicted(kv.key, kv.value)
+	}
+}
+
+// deleteExpired deletes expired records. Has to be called with lock!
+func (c *ExpirableLRU) deleteExpired() {
+	for _, key := range c.keys() {
+		if time.Now().After(c.items[key].Value.(*expirableEntry).expiresAt) {
+			c.removeElement(c.items[key])
+			continue
+		}
+	}
+}
+
+// expirableEntry is used to hold a value in the evictList
+type expirableEntry struct {
+	key       interface{}
+	value     interface{}
+	expiresAt time.Time
+}

--- a/simplelru/expirable_lru_test.go
+++ b/simplelru/expirable_lru_test.go
@@ -1,0 +1,326 @@
+package simplelru
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestExpirableLRUInterface(t *testing.T) {
+	var _ LRUCache = &ExpirableLRU{}
+}
+
+func TestExpirableLRUNoPurge(t *testing.T) {
+	lc := NewExpirableLRU(10, nil, 0, 0)
+
+	lc.Add("key1", "val1")
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+
+	v, ok := lc.Peek("key1")
+	if v != "val1" {
+		t.Fatalf("value differs from expected")
+	}
+	if !ok {
+		t.Fatalf("should be true")
+	}
+
+	if !lc.Contains("key1") {
+		t.Fatalf("should contain key1")
+	}
+	if lc.Contains("key2") {
+		t.Fatalf("should not contain key2")
+	}
+
+	v, ok = lc.Peek("key2")
+	if v != nil {
+		t.Fatalf("should be empty")
+	}
+	if ok {
+		t.Fatalf("should be false")
+	}
+
+	if !reflect.DeepEqual(lc.Keys(), []interface{}{"key1"}) {
+		t.Fatalf("value differs from expected")
+	}
+
+	if lc.Resize(0) != 0 {
+		t.Fatalf("evicted count differs from expected")
+	}
+	if lc.Resize(2) != 0 {
+		t.Fatalf("evicted count differs from expected")
+	}
+	lc.Add("key2", "val2")
+	if lc.Resize(1) != 1 {
+		t.Fatalf("evicted count differs from expected")
+	}
+}
+
+func TestExpirableLRUWithPurge(t *testing.T) {
+	var evicted []string
+	lc := NewExpirableLRU(10, func(key interface{}, value interface{}) { evicted = append(evicted, key.(string), value.(string)) }, 150*time.Millisecond, time.Millisecond*100)
+	defer lc.Close()
+
+	k, v, ok := lc.GetOldest()
+	if k != nil {
+		t.Fatalf("should be empty")
+	}
+	if v != nil {
+		t.Fatalf("should be empty")
+	}
+	if ok {
+		t.Fatalf("should be false")
+	}
+
+	lc.Add("key1", "val1")
+
+	time.Sleep(100 * time.Millisecond) // not enough to expire
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+
+	v, ok = lc.Get("key1")
+	if v != "val1" {
+		t.Fatalf("value differs from expected")
+	}
+	if !ok {
+		t.Fatalf("should be true")
+	}
+
+	time.Sleep(200 * time.Millisecond) // expire
+	v, ok = lc.Get("key1")
+	if ok {
+		t.Fatalf("should be false")
+	}
+	if v != nil {
+		t.Fatalf("should be nil")
+	}
+
+	if lc.Len() != 0 {
+		t.Fatalf("length differs from expected")
+	}
+	if !reflect.DeepEqual(evicted, []string{"key1", "val1"}) {
+		t.Fatalf("value differs from expected")
+	}
+
+	// add new entry
+	lc.Add("key2", "val2")
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+
+	k, v, ok = lc.GetOldest()
+	if k != "key2" {
+		t.Fatalf("value differs from expected")
+	}
+	if v != "val2" {
+		t.Fatalf("value differs from expected")
+	}
+	if !ok {
+		t.Fatalf("should be true")
+	}
+
+	// DeleteExpired, nothing deleted
+	lc.DeleteExpired()
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+	if !reflect.DeepEqual(evicted, []string{"key1", "val1"}) {
+		t.Fatalf("value differs from expected")
+	}
+
+	// Purge, cache should be clean
+	lc.Purge()
+	if lc.Len() != 0 {
+		t.Fatalf("length differs from expected")
+	}
+	if !reflect.DeepEqual(evicted, []string{"key1", "val1", "key2", "val2"}) {
+		t.Fatalf("value differs from expected")
+	}
+}
+
+func TestExpirableLRUWithPurgeEnforcedBySize(t *testing.T) {
+	lc := NewExpirableLRU(10, nil, time.Hour, 0)
+	defer lc.Close()
+
+	for i := 0; i < 100; i++ {
+		i := i
+		lc.Add(fmt.Sprintf("key%d", i), fmt.Sprintf("val%d", i))
+		v, ok := lc.Get(fmt.Sprintf("key%d", i))
+		if v != fmt.Sprintf("val%d", i) {
+			t.Fatalf("value differs from expected")
+		}
+		if !ok {
+			t.Fatalf("should be true")
+		}
+		if lc.Len() > 20 {
+			t.Fatalf("length should be less than 20")
+		}
+	}
+
+	if lc.Len() != 10 {
+		t.Fatalf("length differs from expected")
+	}
+}
+
+func TestExpirableLRUConcurrency(t *testing.T) {
+	lc := NewExpirableLRU(0, nil, 0, 0)
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func(i int) {
+			lc.Add(fmt.Sprintf("key-%d", i/10), fmt.Sprintf("val-%d", i/10))
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	if lc.Len() != 100 {
+		t.Fatalf("length differs from expected")
+	}
+}
+
+func TestExpirableLRUInvalidateAndEvict(t *testing.T) {
+	var evicted int
+	lc := NewExpirableLRU(-1, func(_, _ interface{}) { evicted++ }, 0, 0)
+
+	lc.Add("key1", "val1")
+	lc.Add("key2", "val2")
+
+	val, ok := lc.Get("key1")
+	if !ok {
+		t.Fatalf("should be true")
+	}
+	if val != "val1" {
+		t.Fatalf("value differs from expected")
+	}
+	if evicted != 0 {
+		t.Fatalf("value differs from expected")
+	}
+
+	lc.Remove("key1")
+	if evicted != 1 {
+		t.Fatalf("value differs from expected")
+	}
+	val, ok = lc.Get("key1")
+	if val != nil {
+		t.Fatalf("should be empty")
+	}
+	if ok {
+		t.Fatalf("should be false")
+	}
+}
+
+func TestLoadingExpired(t *testing.T) {
+	lc := NewExpirableLRU(0, nil, time.Millisecond*5, 0)
+
+	lc.Add("key1", "val1")
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+
+	v, ok := lc.Peek("key1")
+	if v != "val1" {
+		t.Fatalf("value differs from expected")
+	}
+	if !ok {
+		t.Fatalf("should be true")
+	}
+
+	v, ok = lc.Get("key1")
+	if v != "val1" {
+		t.Fatalf("value differs from expected")
+	}
+	if !ok {
+		t.Fatalf("should be true")
+	}
+
+	time.Sleep(time.Millisecond * 10) // wait for entry to expire
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	} // but not purged
+
+	v, ok = lc.Peek("key1")
+	if v != nil {
+		t.Fatalf("should be empty")
+	}
+	if ok {
+		t.Fatalf("should be false")
+	}
+
+	v, ok = lc.Get("key1")
+	if v != nil {
+		t.Fatalf("should be empty")
+	}
+	if ok {
+		t.Fatalf("should be false")
+	}
+}
+
+func TestExpirableLRURemoveOldest(t *testing.T) {
+	lc := NewExpirableLRU(2, nil, 0, 0)
+
+	k, v, ok := lc.RemoveOldest()
+	if k != nil {
+		t.Fatalf("should be empty")
+	}
+	if v != nil {
+		t.Fatalf("should be empty")
+	}
+	if ok {
+		t.Fatalf("should be false")
+	}
+
+	ok = lc.Remove("non_existent")
+	if ok {
+		t.Fatalf("should be false")
+	}
+
+	lc.Add("key1", "val1")
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+
+	v, ok = lc.Get("key1")
+	if !ok {
+		t.Fatalf("should be true")
+	}
+	if v != "val1" {
+		t.Fatalf("value differs from expected")
+	}
+
+	if !reflect.DeepEqual(lc.Keys(), []interface{}{"key1"}) {
+		t.Fatalf("value differs from expected")
+	}
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+
+	lc.Add("key2", "val2")
+	if !reflect.DeepEqual(lc.Keys(), []interface{}{"key1", "key2"}) {
+		t.Fatalf("value differs from expected")
+	}
+	if lc.Len() != 2 {
+		t.Fatalf("length differs from expected")
+	}
+
+	k, v, ok = lc.RemoveOldest()
+	if k != "key1" {
+		t.Fatalf("value differs from expected")
+	}
+	if v != "val1" {
+		t.Fatalf("value differs from expected")
+	}
+	if !ok {
+		t.Fatalf("should be true")
+	}
+
+	if !reflect.DeepEqual(lc.Keys(), []interface{}{"key2"}) {
+		t.Fatalf("value differs from expected")
+	}
+	if lc.Len() != 1 {
+		t.Fatalf("length differs from expected")
+	}
+}

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -158,6 +158,9 @@ func (c *LRU) Resize(size int) (evicted int) {
 	return diff
 }
 
+// Close does nothing for this type of cache.
+func (c *LRU) Close() {}
+
 // removeOldest removes the oldest item from the cache.
 func (c *LRU) removeOldest() {
 	ent := c.evictList.Back()

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -35,6 +35,9 @@ type LRUCache interface {
 	// Clears all cache entries.
 	Purge()
 
+	// Closes all hanging goroutines.
+	Close()
+
 	// Resizes cache, returning number evicted
 	Resize(int) int
 }


### PR DESCRIPTION
My attempt at expirable cache implementation, similar to what was done in #41. I've tried to make new cache as close as possible to the existing one in terms of code style and behavior.

The only difference which I did leave in place is that `size=0` on this type of cache means _unlimited_, which makes sense with the expirable cache.

Original work was done in [lcw](https://github.com/paskal/lcw/tree/lru_internal) but it turned out that I don't need it there and I thought it would be nice to add my changes to upstream (this repo).