### PR TITLE
support simple expiring cache

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -16,6 +16,9 @@
 // ARC has been patented by IBM, so do not use it if that is problematic for
 // your program.
 //
+// ExpiringCache wraps one of the above caches and make their entries expiring
+// according to policies:  ExpireAfterAccess or ExpireAfterWrite.
+//
 // All caches in this package take locks while operating, and are therefore
 // thread-safe for consumers.
 package lru

--- a/expiringlru.go
+++ b/expiringlru.go
@@ -1,0 +1,356 @@
+package lru
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"time"
+)
+
+//common interface shared by 2q, arc and simple LRU, used as interface of backing LRU
+type lruCache interface {
+	// Adds a value to the cache, returns evicted <k,v> if happened and
+	// updates the "recently used"-ness of the key.
+	Add(k, v interface{}, evictedKeyVal ...*interface{}) (evicted bool)
+	// Returns key's value from the cache if found and
+	// updates the "recently used"-ness of the key.
+	Get(k interface{}) (v interface{}, ok bool)
+	// Removes a key from the cache
+	Remove(k interface{}) bool
+	// Returns key's value without updating the "recently used"-ness of the key.
+	Peek(key interface{}) (value interface{}, ok bool)
+	// Checks if a key exists in cache without updating the recent-ness.
+	Contains(k interface{}) bool
+	// Returns a slice of the keys in the cache, from oldest to newest.
+	Keys() []interface{}
+	// Returns the number of items in the cache.
+	Len() int
+	// Clears all cache entries.
+	Purge()
+}
+
+type entry struct {
+	key            interface{}
+	val            interface{}
+	expirationTime time.Time
+	elem           *list.Element
+}
+
+func (e entry) String() string {
+	return fmt.Sprintf("%v,%v  %v", e.key, e.val, e.expirationTime)
+}
+
+//two expiration policies
+type expiringType byte
+
+const (
+	expireAfterWrite expiringType = iota
+	expireAfterAccess
+)
+
+// ExpiringCache will wrap an existing LRU and make its entries expiring
+// according to two policies:
+// expireAfterAccess and expireAfterWrite (default)
+// Internally keep a expireList sorted by entries' expirationTime
+type ExpiringCache struct {
+	lru        lruCache
+	expiration time.Duration
+	expireList *expireList
+	expireType expiringType
+	//placeholder for time.Now() for easier testing setup
+	timeNow func() time.Time
+	lock    RWLocker
+}
+
+// OptionExp defines option to customize ExpiringCache
+type OptionExp func(c *ExpiringCache) error
+
+// NewExpiring2Q creates an expiring cache with specifized
+// size and entries lifetime duration, backed by a 2-queue LRU
+func NewExpiring2Q(size int, expir time.Duration, opts ...OptionExp) (elru *ExpiringCache, err error) {
+	//create a non synced LRU as backing store
+	lru, err := New2Q(size, NoLock2Q)
+	if err != nil {
+		return
+	}
+	elru, err = Expiring(expir, lru, opts...)
+	return
+}
+
+// NewExpiringARC creates an expiring cache with specifized
+// size and entries lifetime duration, backed by a ARC LRU
+func NewExpiringARC(size int, expir time.Duration, opts ...OptionExp) (elru *ExpiringCache, err error) {
+	//create a non synced LRU as backing store
+	lru, err := NewARC(size, NoLockARC)
+	if err != nil {
+		return
+	}
+	elru, err = Expiring(expir, lru, opts...)
+	return
+}
+
+// NewExpiringLRU creates an expiring cache with specifized
+// size and entries lifetime duration, backed by a simple LRU
+func NewExpiringLRU(size int, expir time.Duration, opts ...OptionExp) (elru *ExpiringCache, err error) {
+	//create a non synced LRU as backing store
+	lru, err := New(size, NoLock)
+	if err != nil {
+		return
+	}
+	elru, err = Expiring(expir, lru, opts...)
+	return
+}
+
+// Expiring will wrap an existing LRU to make its entries
+// expiring with specified duration
+func Expiring(expir time.Duration, lru lruCache, opts ...OptionExp) (*ExpiringCache, error) {
+	//create expiring cache with default settings
+	elru := &ExpiringCache{
+		lru:        lru,
+		expiration: expir,
+		expireList: newExpireList(),
+		expireType: expireAfterWrite,
+		timeNow:    time.Now,
+		lock:       &sync.RWMutex{},
+	}
+	//apply options to customize
+	for _, opt := range opts {
+		if err := opt(elru); err != nil {
+			return nil, err
+		}
+	}
+	return elru, nil
+}
+
+// NoLockExp disables locking for ExpiringCache
+func NoLockExp(elru *ExpiringCache) error {
+	elru.lock = NoOpRWLocker{}
+	return nil
+}
+
+// ExpireAfterWrite sets expiring policy
+func ExpireAfterWrite(elru *ExpiringCache) error {
+	elru.expireType = expireAfterWrite
+	return nil
+}
+
+// ExpireAfterAccess sets expiring policy
+func ExpireAfterAccess(elru *ExpiringCache) error {
+	elru.expireType = expireAfterAccess
+	return nil
+}
+
+// TimeTicker sets the function used to return current time, for test setup
+func TimeTicker(tn func() time.Time) OptionExp {
+	return func(elru *ExpiringCache) error {
+		elru.timeNow = tn
+		return nil
+	}
+}
+
+// Add add a key/val pair to cache with cache's default expiration duration
+// return evicted key/val pair if eviction happens.
+// Should be used in most cases for better performance
+func (elru *ExpiringCache) Add(k, v interface{}, evictedKeyVal ...*interface{}) (evicted bool) {
+	return elru.AddWithTTL(k, v, elru.expiration, evictedKeyVal...)
+}
+
+// AddWithTTL add a key/val pair to cache with provided expiration duration
+// return evicted key/val pair if eviction happens.
+// Using this with variant expiration durations could cause degraded performance
+func (elru *ExpiringCache) AddWithTTL(k, v interface{}, expiration time.Duration, evictedKeyVal ...*interface{}) (evicted bool) {
+	elru.lock.Lock()
+	defer elru.lock.Unlock()
+	now := elru.timeNow()
+	var ent *entry
+	var expired []*entry
+	if ent0, _ := elru.lru.Peek(k); ent0 != nil {
+		//update existing cache entry
+		ent = ent0.(*entry)
+		ent.val = v
+		ent.expirationTime = now.Add(expiration)
+		elru.expireList.MoveToFront(ent)
+	} else {
+		//first remove 1 possible expiration to add space for new entry
+		expired = elru.removeExpired(now, false)
+		//add new entry to expiration list
+		ent = &entry{
+			key:            k,
+			val:            v,
+			expirationTime: now.Add(expiration),
+		}
+		elru.expireList.PushFront(ent)
+	}
+	// Add/Update cache entry in backing cache
+	var evictedKey, evictedVal interface{}
+	evicted = elru.lru.Add(k, ent, &evictedKey, &evictedVal)
+	//remove evicted ent from expireList
+	if evicted {
+		ent = evictedVal.(*entry)
+		evictedVal = ent.val
+		elru.expireList.Remove(ent)
+	} else if len(expired) > 0 {
+		evictedKey = expired[0].key
+		evictedVal = expired[0].val
+		evicted = true
+	}
+	if evicted && len(evictedKeyVal) > 0 {
+		*evictedKeyVal[0] = evictedKey
+	}
+	if evicted && len(evictedKeyVal) > 1 {
+		*evictedKeyVal[1] = evictedVal
+	}
+	return
+}
+
+// Get returns key's value from the cache if found
+func (elru *ExpiringCache) Get(k interface{}) (v interface{}, ok bool) {
+	elru.lock.Lock()
+	defer elru.lock.Unlock()
+	now := elru.timeNow()
+	if ent0, ok := elru.lru.Get(k); ok {
+		ent := ent0.(*entry)
+		if ent.expirationTime.After(now) {
+			if elru.expireType == expireAfterAccess {
+				ent.expirationTime = now.Add(elru.expiration)
+				elru.expireList.MoveToFront(ent)
+			}
+			return ent.val, true
+		}
+	}
+	return
+}
+
+// Remove removes a key from the cache
+func (elru *ExpiringCache) Remove(k interface{}) bool {
+	elru.lock.Lock()
+	defer elru.lock.Unlock()
+	if ent, _ := elru.lru.Peek(k); ent != nil {
+		elru.expireList.Remove(ent.(*entry))
+		return elru.lru.Remove(k)
+	}
+	return false
+}
+
+// Peek return key's value without updating the "recently used"-ness of the key.
+// returns ok=false if k not found or entry expired
+func (elru *ExpiringCache) Peek(k interface{}) (v interface{}, ok bool) {
+	elru.lock.RLock()
+	defer elru.lock.RUnlock()
+	if ent0, ok := elru.lru.Peek(k); ok {
+		ent := ent0.(*entry)
+		if ent.expirationTime.After(elru.timeNow()) {
+			return ent.val, true
+		}
+		return ent.val, false
+	}
+	return
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (elru *ExpiringCache) Contains(k interface{}) bool {
+	_, ok := elru.Peek(k)
+	return ok
+}
+
+// Keys returns a slice of the keys in the cache.
+// The frequently used keys are first in the returned slice.
+func (elru *ExpiringCache) Keys() []interface{} {
+	elru.lock.Lock()
+	defer elru.lock.Unlock()
+	//to get accurate key set, remove all expired
+	elru.removeExpired(elru.timeNow(), true)
+	return elru.lru.Keys()
+}
+
+// Len returns the number of items in the cache.
+func (elru *ExpiringCache) Len() int {
+	elru.lock.Lock()
+	defer elru.lock.Unlock()
+	//to get accurate size, remove all expired
+	elru.removeExpired(elru.timeNow(), true)
+	return elru.lru.Len()
+}
+
+// Purge is used to completely clear the cache.
+func (elru *ExpiringCache) Purge() {
+	elru.lock.Lock()
+	defer elru.lock.Unlock()
+	elru.expireList.Init()
+	elru.lru.Purge()
+}
+
+//either remove one (the oldest expired), or all expired
+func (elru *ExpiringCache) removeExpired(now time.Time, removeAllExpired bool) (res []*entry) {
+	res = elru.expireList.RemoveExpired(now, removeAllExpired)
+	for i := 0; i < len(res); i++ {
+		elru.lru.Remove(res[i].key)
+	}
+	return
+}
+
+// RemoveAllExpired remove all expired entries, can be called by cleanup goroutine
+func (elru *ExpiringCache) RemoveAllExpired() {
+	elru.removeExpired(elru.timeNow(), true)
+}
+
+// oldest entries are at front of expire list
+type expireList struct {
+	expList *list.List
+}
+
+func newExpireList() *expireList {
+	return &expireList{
+		expList: list.New(),
+	}
+}
+
+func (el *expireList) Init() {
+	el.expList.Init()
+}
+
+func (el *expireList) PushFront(ent *entry) {
+	//When all operations use ExpiringCache default expiration,
+	//PushFront should succeed at first/front entry of list
+	for e := el.expList.Front(); e != nil; e = e.Next() {
+		if !ent.expirationTime.Before(e.Value.(*entry).expirationTime) {
+			ent.elem = el.expList.InsertBefore(ent, e)
+			return
+		}
+	}
+	ent.elem = el.expList.PushBack(ent)
+}
+
+func (el *expireList) MoveToFront(ent *entry) {
+	//When all operations use ExpiringCache default expiration,
+	//MoveToFront should succeed at first/front entry of list
+	for e := el.expList.Front(); e != nil; e = e.Next() {
+		if !ent.expirationTime.Before(e.Value.(*entry).expirationTime) {
+			el.expList.MoveBefore(ent.elem, e)
+			return
+		}
+	}
+	el.expList.MoveAfter(ent.elem, el.expList.Back())
+}
+
+func (el *expireList) Remove(ent *entry) interface{} {
+	return el.expList.Remove(ent.elem)
+}
+
+//either remove one (the oldest expired), or remove all expired
+func (el *expireList) RemoveExpired(now time.Time, removeAllExpired bool) (res []*entry) {
+	for {
+		back := el.expList.Back()
+		if back == nil || back.Value.(*entry).expirationTime.After(now) {
+			break
+		}
+		//expired
+		ent := el.expList.Remove(back).(*entry)
+		res = append(res, ent)
+		if !removeAllExpired {
+			break
+		}
+	}
+	return
+}

--- a/expiringlru_test.go
+++ b/expiringlru_test.go
@@ -1,0 +1,671 @@
+package lru
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+)
+
+func BenchmarkExpiring2Q_Rand(b *testing.B) {
+	l, err := NewExpiring2Q(8192, 5*time.Minute)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		trace[i] = rand.Int63() % 32768
+	}
+
+	b.ResetTimer()
+
+	var hit, miss int
+	for i := 0; i < 2*b.N; i++ {
+		if i%2 == 0 {
+			l.Add(trace[i], trace[i])
+		} else {
+			_, ok := l.Get(trace[i])
+			if ok {
+				hit++
+			} else {
+				miss++
+			}
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkExpiring2Q_Freq(b *testing.B) {
+	l, err := NewExpiring2Q(8192, 5*time.Minute)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		if i%2 == 0 {
+			trace[i] = rand.Int63() % 16384
+		} else {
+			trace[i] = rand.Int63() % 32768
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Add(trace[i], trace[i])
+	}
+	var hit, miss int
+	for i := 0; i < b.N; i++ {
+		_, ok := l.Get(trace[i])
+		if ok {
+			hit++
+		} else {
+			miss++
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkExpiringARC_Rand(b *testing.B) {
+	l, err := NewExpiringARC(8192, 5*time.Minute)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		trace[i] = rand.Int63() % 32768
+	}
+
+	b.ResetTimer()
+
+	var hit, miss int
+	for i := 0; i < 2*b.N; i++ {
+		if i%2 == 0 {
+			l.Add(trace[i], trace[i])
+		} else {
+			_, ok := l.Get(trace[i])
+			if ok {
+				hit++
+			} else {
+				miss++
+			}
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkExpiringARC_Freq(b *testing.B) {
+	l, err := NewExpiringARC(8192, 5*time.Minute)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		if i%2 == 0 {
+			trace[i] = rand.Int63() % 16384
+		} else {
+			trace[i] = rand.Int63() % 32768
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Add(trace[i], trace[i])
+	}
+	var hit, miss int
+	for i := 0; i < b.N; i++ {
+		_, ok := l.Get(trace[i])
+		if ok {
+			hit++
+		} else {
+			miss++
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkExpiringLRU_Rand(b *testing.B) {
+	l, err := NewExpiringLRU(8192, 5*time.Minute)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		trace[i] = rand.Int63() % 32768
+	}
+
+	b.ResetTimer()
+
+	var hit, miss int
+	for i := 0; i < 2*b.N; i++ {
+		if i%2 == 0 {
+			l.Add(trace[i], trace[i])
+		} else {
+			_, ok := l.Get(trace[i])
+			if ok {
+				hit++
+			} else {
+				miss++
+			}
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkExpiringLRU_Freq(b *testing.B) {
+	l, err := NewExpiringLRU(8192, 5*time.Minute)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		if i%2 == 0 {
+			trace[i] = rand.Int63() % 16384
+		} else {
+			trace[i] = rand.Int63() % 32768
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Add(trace[i], trace[i])
+	}
+	var hit, miss int
+	for i := 0; i < b.N; i++ {
+		_, ok := l.Get(trace[i])
+		if ok {
+			hit++
+		} else {
+			miss++
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func TestExpiring2Q_RandomOps(t *testing.T) {
+	size := 128
+	l, err := NewExpiring2Q(size, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	n := 200000
+	for i := 0; i < n; i++ {
+		key := rand.Int63() % 512
+		r := rand.Int63()
+		switch r % 3 {
+		case 0:
+			l.Add(key, key)
+		case 1:
+			l.Get(key)
+		case 2:
+			l.Remove(key)
+		}
+
+		if l.Len() > size {
+			t.Fatalf("bad ExpiringCache size: %d, expected: %d",
+				l.Len(), size)
+		}
+	}
+}
+
+func TestExpiringARC_RandomOps(t *testing.T) {
+	size := 128
+	l, err := NewExpiringARC(size, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	n := 200000
+	for i := 0; i < n; i++ {
+		key := rand.Int63() % 512
+		r := rand.Int63()
+		switch r % 3 {
+		case 0:
+			l.Add(key, key)
+		case 1:
+			l.Get(key)
+		case 2:
+			l.Remove(key)
+		}
+
+		if l.Len() > size {
+			t.Fatalf("bad ExpiringCache size: %d, expected: %d",
+				l.Len(), size)
+		}
+	}
+}
+
+func TestExpiringLRU_RandomOps(t *testing.T) {
+	size := 128
+	l, err := NewExpiringLRU(size, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	n := 200000
+	for i := 0; i < n; i++ {
+		key := rand.Int63() % 512
+		r := rand.Int63()
+		switch r % 3 {
+		case 0:
+			l.Add(key, key)
+		case 1:
+			l.Get(key)
+		case 2:
+			l.Remove(key)
+		}
+
+		if l.Len() > size {
+			t.Fatalf("bad ExpiringCache size: %d, expected: %d",
+				l.Len(), size)
+		}
+	}
+}
+
+// Test eviction by least-recently-used (2-queue LRU suuport retaining frequently-used)
+func TestExpiring2Q_EvictionByLRU(t *testing.T) {
+	elru, err := NewExpiring2Q(3, 30*time.Second)
+	if err != nil {
+		t.Fatalf("failed to create expiring LRU")
+	}
+	for i := 0; i < 2; i++ {
+		elru.Add(i, i)
+	}
+	elru.Add(2, 2)
+	//Get(0),Get(1) will move 0, 1 to freq-used list
+	//2 will remain in recent-used list
+	for i := 0; i < 2; i++ {
+		elru.Get(i)
+	}
+	//next add 3,4; verify 2, 3 will be evicted
+	var ek, ev interface{}
+	for i := 3; i < 5; i++ {
+		evicted := elru.Add(i, i, &ek, &ev)
+		k, v := ek.(int), ev.(int)
+		if !evicted || k != (i-1) || v != (i-1) {
+			t.Fatalf("(%v %v) should be evicted, but got (%v,%v)", i-1, i-1, k, v)
+		}
+	}
+	if elru.Len() != 3 {
+		t.Fatalf("Expiring LRU eviction failed, expected 3 entries left, but found %v", elru.Len())
+	}
+	keys := elru.Keys()
+	//since 0, 1 are touched twice (write & read) so
+	//they are in frequently used list, they are kept
+	//and 2,3,4 only touched once (write), so they
+	//moved thru "recent" list, with 2,3 evicted
+	for i, v := range []int{0, 1, 4} {
+		if v != keys[i] {
+			t.Fatalf("Expiring LRU eviction failed, expected keys {0,1,4} left, but found %v", elru.Keys())
+		}
+	}
+}
+
+//testTimer used to simulate time-elapse for expiration tests
+type testTimer struct {
+	t time.Time
+}
+
+func newTestTimer() *testTimer                { return &testTimer{time.Now()} }
+func (tt *testTimer) Now() time.Time          { return tt.t }
+func (tt *testTimer) Advance(d time.Duration) { tt.t = tt.t.Add(d) }
+
+// Test eviction by ExpireAfterWrite
+func TestExpiring2Q_ExpireAfterWrite(t *testing.T) {
+	//use test timer for expiration
+	tt := newTestTimer()
+	elru, err := NewExpiring2Q(3, 30*time.Second, TimeTicker(tt.Now))
+	if err != nil {
+		t.Fatalf("failed to create expiring LRU")
+	}
+	for i := 0; i < 2; i++ {
+		elru.Add(i, i)
+	}
+	//test timer ticks 20 seconds
+	tt.Advance(20 * time.Second)
+	//add fresher entry <2,2> to cache
+	elru.Add(2, 2)
+	//Get(0),Get(1) will move 0, 1 to freq-used list
+	//2 will remain in recent-used list
+	for i := 0; i < 2; i++ {
+		elru.Get(i)
+	}
+	//test timer advance another 15 seconds, entries <0,0>,<1,1> timeout & expire now,
+	//so they should be evicted, although they are more recently retrieved than <2,2>
+	tt.Advance(15 * time.Second)
+	//next add 3,4; verify 0,1 will be evicted
+	var ek, ev interface{}
+	for i := 3; i < 5; i++ {
+		evicted := elru.Add(i, i, &ek, &ev)
+		k, v := ek.(int), ev.(int)
+		if !evicted || k != (i-3) || v != (i-3) {
+			t.Fatalf("(%v %v) should be evicted, but got (%v,%v)", i-3, i-3, k, v)
+		}
+	}
+	if elru.Len() != 3 {
+		t.Fatalf("Expiring LRU eviction failed, expected 3 entries left, but found %v", elru.Len())
+	}
+	keys := elru.Keys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].(int) < keys[j].(int) })
+	//althoug 0, 1 are touched twice (write & read) so
+	//they are in frequently used list, they are evicted because expiration
+	//and 2,3,4 will be kept
+	for i, v := range []int{2, 3, 4} {
+		if v != keys[i] {
+			t.Fatalf("Expiring LRU eviction failed, expected keys {2,3,4} left, but found %v", elru.Keys())
+		}
+	}
+}
+
+// Test eviction by ExpireAfterAccess: basically same access sequence as above case
+// but different result because of ExpireAfterAccess
+func TestExpiring2Q_ExpireAfterAccess(t *testing.T) {
+	//use test timer for expiration
+	tt := newTestTimer()
+	elru, err := NewExpiring2Q(3, 30*time.Second, TimeTicker(tt.Now), ExpireAfterAccess)
+	if err != nil {
+		t.Fatalf("failed to create expiring LRU")
+	}
+	for i := 0; i < 2; i++ {
+		elru.Add(i, i)
+	}
+	//test timer ticks 20 seconds
+	tt.Advance(20 * time.Second)
+	//add fresher entry <2,2> to cache
+	elru.Add(2, 2)
+	//Get(0),Get(1) will move 0, 1 to freq-used list
+	//also moved them to back in expire list with newer timestamp
+	//2 will remain in recent-used list
+	for i := 0; i < 2; i++ {
+		elru.Get(i)
+	}
+	//test timer advance another 15 seconds, none expired
+	//and 2 in recent list
+	tt.Advance(15 * time.Second)
+	//next add 3,4; verify 2,3 will be evicted, because 0,1 in freq list, not expired
+	for i := 3; i < 5; i++ {
+		elru.Add(i, i)
+	}
+	if elru.Len() != 3 {
+		t.Fatalf("Expiring LRU eviction failed, expected 3 entries left, but found %v", elru.Len())
+	}
+	keys := elru.Keys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].(int) < keys[j].(int) })
+	//and 0,1,4 will be kept
+	for i, v := range []int{0, 1, 4} {
+		if v != keys[i] {
+			t.Fatalf("Expiring LRU eviction failed, expected keys {0,1,4} left, but found %v", elru.Keys())
+		}
+	}
+}
+
+// Test eviction by ExpireAfterWrite
+func TestExpiringARC_ExpireAfterWrite(t *testing.T) {
+	//use test timer for expiration
+	tt := newTestTimer()
+	elru, err := NewExpiringARC(3, 30*time.Second, TimeTicker(tt.Now))
+	if err != nil {
+		t.Fatalf("failed to create expiring LRU")
+	}
+	for i := 0; i < 2; i++ {
+		elru.Add(i, i)
+	}
+	//test timer ticks 20 seconds
+	tt.Advance(20 * time.Second)
+	//add fresher entry <2,2> to cache
+	elru.Add(2, 2)
+	//Get(0),Get(1) will move 0, 1 to freq-used list
+	//2 will remain in recent-used list
+	for i := 0; i < 2; i++ {
+		elru.Get(i)
+	}
+	//test timer advance another 15 seconds, entries <0,0>,<1,1> timeout & expire now,
+	//so they should be evicted, although they are more recently retrieved than <2,2>
+	tt.Advance(15 * time.Second)
+	//next add 3,4; verify 0,1 will be evicted
+	var ek, ev interface{}
+	for i := 3; i < 5; i++ {
+		evicted := elru.Add(i, i, &ek, &ev)
+		k, v := ek.(int), ev.(int)
+		if !evicted || k != (i-3) || v != (i-3) {
+			t.Fatalf("(%v %v) should be evicted, but got (%v,%v)", i-3, i-3, k, v)
+		}
+	}
+	if elru.Len() != 3 {
+		t.Fatalf("Expiring LRU eviction failed, expected 3 entries left, but found %v", elru.Len())
+	}
+	keys := elru.Keys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].(int) < keys[j].(int) })
+	//althoug 0, 1 are touched twice (write & read) so
+	//they are in frequently used list, they are evicted because expiration
+	//and 2,3,4 will be kept
+	for i, v := range []int{2, 3, 4} {
+		if v != keys[i] {
+			t.Fatalf("Expiring LRU eviction failed, expected keys {2,3,4} left, but found %v", elru.Keys())
+		}
+	}
+}
+
+// Test eviction by ExpireAfterAccess: basically same access sequence as above case
+// but different result because of ExpireAfterAccess
+func TestExpiringARC_ExpireAfterAccess(t *testing.T) {
+	//use test timer for expiration
+	tt := newTestTimer()
+	elru, err := NewExpiringARC(3, 30*time.Second, TimeTicker(tt.Now), ExpireAfterAccess)
+	if err != nil {
+		t.Fatalf("failed to create expiring LRU")
+	}
+	for i := 0; i < 2; i++ {
+		elru.Add(i, i)
+	}
+	//test timer ticks 20 seconds
+	tt.Advance(20 * time.Second)
+	//add fresher entry <2,2> to cache
+	elru.Add(2, 2)
+	//Get(0),Get(1) will move 0, 1 to freq-used list
+	//also moved them to back in expire list with newer timestamp
+	//2 will remain in recent-used list
+	for i := 0; i < 2; i++ {
+		elru.Get(i)
+	}
+	//test timer advance another 15 seconds, none expired
+	//and 2 in recent list
+	tt.Advance(15 * time.Second)
+	//next add 3,4; verify 2,3 will be evicted, because 0,1 in freq list, not expired
+	for i := 3; i < 5; i++ {
+		elru.Add(i, i)
+	}
+	if elru.Len() != 3 {
+		t.Fatalf("Expiring LRU eviction failed, expected 3 entries left, but found %v", elru.Len())
+	}
+	keys := elru.Keys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].(int) < keys[j].(int) })
+	//and 0,1,4 will be kept
+	for i, v := range []int{0, 1, 4} {
+		if v != keys[i] {
+			t.Fatalf("Expiring LRU eviction failed, expected keys {0,1,4} left, but found %v", elru.Keys())
+		}
+	}
+}
+
+// Test eviction by ExpireAfterWrite
+func TestExpiringLRU_ExpireAfterWrite(t *testing.T) {
+	//use test timer for expiration
+	tt := newTestTimer()
+	elru, err := NewExpiringLRU(3, 30*time.Second, TimeTicker(tt.Now))
+	if err != nil {
+		t.Fatalf("failed to create expiring LRU")
+	}
+	for i := 0; i < 2; i++ {
+		elru.Add(i, i)
+	}
+	//test timer ticks 20 seconds
+	tt.Advance(20 * time.Second)
+	//add fresher entry <2,2> to cache
+	elru.Add(2, 2)
+	//Get(0),Get(1) will move 0, 1 to freq-used list
+	//2 will remain in recent-used list
+	for i := 0; i < 2; i++ {
+		elru.Get(i)
+	}
+	//test timer advance another 15 seconds, entries <0,0>,<1,1> timeout & expire now,
+	//so they should be evicted, although they are more recently retrieved than <2,2>
+	tt.Advance(15 * time.Second)
+	//next add 3,4; verify 0,1 will be evicted
+	var ek, ev interface{}
+	for i := 3; i < 5; i++ {
+		evicted := elru.Add(i, i, &ek, &ev)
+		k, v := ek.(int), ev.(int)
+		if !evicted || k != (i-3) || v != (i-3) {
+			t.Fatalf("(%v %v) should be evicted, but got (%v,%v)", i-3, i-3, k, v)
+		}
+	}
+	if elru.Len() != 3 {
+		t.Fatalf("Expiring LRU eviction failed, expected 3 entries left, but found %v", elru.Len())
+	}
+	keys := elru.Keys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].(int) < keys[j].(int) })
+	//althoug 0, 1 are touched twice (write & read) so
+	//they are in frequently used list, they are evicted because expiration
+	//and 2,3,4 will be kept
+	for i, v := range []int{2, 3, 4} {
+		if v != keys[i] {
+			t.Fatalf("Expiring LRU eviction failed, expected keys {2,3,4} left, but found %v", elru.Keys())
+		}
+	}
+}
+
+// Test eviction by ExpireAfterAccess: basically same access sequence as above case
+// but different result because of ExpireAfterAccess
+func TestExpiringLRU_ExpireAfterAccess(t *testing.T) {
+	//use test timer for expiration
+	tt := newTestTimer()
+	elru, err := NewExpiringLRU(3, 30*time.Second, TimeTicker(tt.Now), ExpireAfterAccess)
+	if err != nil {
+		t.Fatalf("failed to create expiring LRU")
+	}
+	for i := 0; i < 2; i++ {
+		elru.Add(i, i)
+	}
+	//test timer ticks 20 seconds
+	tt.Advance(20 * time.Second)
+	//add fresher entry <2,2> to cache
+	elru.Add(2, 2)
+	//Get(0),Get(1) will move 0, 1 to back of access list
+	//also moved them to back in expire list with newer timestamp
+	//access list will be 2,0,1
+	for i := 0; i < 2; i++ {
+		elru.Get(i)
+	}
+	//test timer advance another 15 seconds, none expired
+	tt.Advance(15 * time.Second)
+	//next add 3,4; verify 2,0 will be evicted
+	for i := 3; i < 5; i++ {
+		elru.Add(i, i)
+	}
+	if elru.Len() != 3 {
+		t.Fatalf("Expiring LRU eviction failed, expected 3 entries left, but found %v", elru.Len())
+	}
+	keys := elru.Keys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].(int) < keys[j].(int) })
+	//and 1,3,4 will be kept
+	for i, v := range []int{1, 3, 4} {
+		if v != keys[i] {
+			t.Fatalf("Expiring LRU eviction failed, expected keys {1,3,4} left, but found %v", elru.Keys())
+		}
+	}
+}
+
+func TestExpiring2Q(t *testing.T) {
+	l, err := NewExpiring2Q(128, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+// Test that Contains doesn't update recent-ness
+func TestExpiring2Q_Contains(t *testing.T) {
+	l, err := NewExpiring2Q(2, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// Test that Peek doesn't update recent-ness
+func TestExpiring2Q_Peek(t *testing.T) {
+	l, err := NewExpiring2Q(2, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}

--- a/lru.go
+++ b/lru.go
@@ -9,25 +9,42 @@ import (
 // Cache is a thread-safe fixed size LRU cache.
 type Cache struct {
 	lru  simplelru.LRUCache
-	lock sync.RWMutex
+	lock RWLocker
 }
 
+// Option to customize LRUCache
+type Option func(*Cache) error
+
 // New creates an LRU of the given size.
-func New(size int) (*Cache, error) {
-	return NewWithEvict(size, nil)
+func New(size int, opts ...Option) (*Cache, error) {
+	return NewWithEvict(size, nil, opts...)
 }
 
 // NewWithEvict constructs a fixed size cache with the given eviction
 // callback.
-func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) (*Cache, error) {
+func NewWithEvict(size int, onEvicted func(key interface{}, value interface{}), opts ...Option) (*Cache, error) {
+	//create a cache with default settings
 	lru, err := simplelru.NewLRU(size, simplelru.EvictCallback(onEvicted))
 	if err != nil {
 		return nil, err
 	}
 	c := &Cache{
-		lru: lru,
+		lru:  lru,
+		lock: &sync.RWMutex{},
+	}
+	//apply options for custimization
+	for _, opt := range opts {
+		if err = opt(c); err != nil {
+			return nil, err
+		}
 	}
 	return c, nil
+}
+
+// NoLock disables locking for LRUCache
+func NoLock(c *Cache) error {
+	c.lock = NoOpRWLocker{}
+	return nil
 }
 
 // Purge is used to completely clear the cache.
@@ -37,10 +54,10 @@ func (c *Cache) Purge() {
 	c.lock.Unlock()
 }
 
-// Add adds a value to the cache. Returns true if an eviction occurred.
-func (c *Cache) Add(key, value interface{}) (evicted bool) {
+// Add adds a value to the cache. Returns true and evicted key/val if an eviction occurred.
+func (c *Cache) Add(key, value interface{}, evictedKeyVal ...*interface{}) (evicted bool) {
 	c.lock.Lock()
-	evicted = c.lru.Add(key, value)
+	evicted = c.lru.Add(key, value, evictedKeyVal...)
 	c.lock.Unlock()
 	return evicted
 }

--- a/rwlocker.go
+++ b/rwlocker.go
@@ -1,0 +1,24 @@
+package lru
+
+// RWLocker define base interface of sync.RWMutex
+type RWLocker interface {
+	Lock()
+	Unlock()
+	RLock()
+	RUnlock()
+}
+
+// NoOpRWLocker is a dummy noop implementation of RWLocker interface
+type NoOpRWLocker struct{}
+
+// Lock perform noop Lock() operation
+func (nop NoOpRWLocker) Lock() {}
+
+// Unlock perform noop Unlock() operation
+func (nop NoOpRWLocker) Unlock() {}
+
+// RLock perform noop RLock() operation
+func (nop NoOpRWLocker) RLock() {}
+
+// RUnlock perform noop RUnlock() operation
+func (nop NoOpRWLocker) RUnlock() {}

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -48,7 +48,7 @@ func (c *LRU) Purge() {
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occurred.
-func (c *LRU) Add(key, value interface{}) (evicted bool) {
+func (c *LRU) Add(key, value interface{}, evictedKeyVal ...*interface{}) (evict bool) {
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
@@ -61,12 +61,18 @@ func (c *LRU) Add(key, value interface{}) (evicted bool) {
 	entry := c.evictList.PushFront(ent)
 	c.items[key] = entry
 
-	evict := c.evictList.Len() > c.size
+	evict = c.evictList.Len() > c.size
 	// Verify size not exceeded
 	if evict {
-		c.removeOldest()
+		k, v, _ := c.RemoveOldest()
+		if len(evictedKeyVal) > 0 {
+			*evictedKeyVal[0] = k
+		}
+		if len(evictedKeyVal) > 1 {
+			*evictedKeyVal[1] = v
+		}
 	}
-	return evict
+	return
 }
 
 // Get looks up a key's value from the cache.

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -3,9 +3,9 @@ package simplelru
 
 // LRUCache is the interface for simple LRU cache.
 type LRUCache interface {
-	// Adds a value to the cache, returns true if an eviction occurred and
-	// updates the "recently used"-ness of the key.
-	Add(key, value interface{}) bool
+	// Adds a value to the cache, returns true if an eviction occurred
+	// return evicted key/val and updates the "recently used"-ness of the key.
+	Add(key, value interface{}, evictedKeyVal ...*interface{}) bool
 
 	// Returns key's value from the cache and
 	// updates the "recently used"-ness of the key. #value, isFound
@@ -36,5 +36,5 @@ type LRUCache interface {
 	Purge()
 
 	// Resizes cache, returning number evicted
-	Resize(int) int
+	Resize(size int) int
 }


### PR DESCRIPTION
Please review changes to support simple expiring cache:

* reuse existing 2q, arc and simple lru for lru eviction, add expiring logic as a wrapper; need changes in current api Add() method to return evicted key/val.

* since there are 3000+ packages importing golang-lru, avoid api changes that require user code change; the changes to api Add() method (single change to LRUCache interface) is introduced as optional argument:
  
    Add(key, val interface{}, evictedKeyVal ...*interface{}) (evicted bool)

  this is "pull" style api: user/caller code specify receiving arguments to receive results from callee, similar to Reader{ Read(recvBuf []byte)int }:

    Add(k,v) //current code, no change

    Add(k,v,&evictedKey) //interested in evicted key

    Add(k,v,&evictedKey,&evictedVal) //interested in both evicted key and val

* since ExpringCache will be synced(RWMutex) and its wrapped caches (TwoQueueCache, etc.) are by default synced,  the embedded layer of locking is not necessary. add an optional argument "NoLock" to all Caches' constructors. when created with NoLock, caches will be equipped with a noop dummy RWLocker. 

* there are 2 expiring policies similar to Guava's CacheBuilder (https://guava.dev/releases/19.0/api/docs/com/google/common/cache/CacheBuilder.html): ExpireAfterWrite and ExpireAfterAccess

* the default cleanup of expired entries is lazy, only when space is needed for new entries; can add background cleanup by a goroutine periodically calling RemoveAllExpired()

