### PR TITLE
Tslru- thread safe lru

### DIFF
--- a/tslru.go
+++ b/tslru.go
@@ -28,8 +28,7 @@ func (c *TSCache) Purge() {
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
 func (c *TSCache) Add(key, value interface{}) (evicted bool) {
-	evicted = c.lru.Add(key, value)
-	return
+	return c.lru.Add(key, value)
 }
 
 // Get looks up a key's value from the cache.
@@ -77,8 +76,7 @@ func (c *TSCache) Remove(key interface{}) (present bool) {
 
 // Resize changes the cache size.
 func (c *TSCache) Resize(size int) (evicted int) {
-	c.lru.Resize(size)
-	return
+	return c.lru.Resize(size)
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.

--- a/tslru.go
+++ b/tslru.go
@@ -1,0 +1,92 @@
+package lru
+
+import (
+	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/tslru"
+)
+
+// TSCache is a thread-safe fixed size LRU cache.
+type TSCache struct {
+	// Fragmentation can reduce lock contention, but the hash function affects efficiency
+	lru simplelru.LRUCache
+}
+
+// NewTSCache creates an LRU of the given size.
+func NewTSCache(size int) (c *TSCache, err error) {
+	// create a cache with default settings
+	lru, err := tslru.NewLRU(size)
+	if err != nil {
+		return nil, err
+	}
+	return &TSCache{lru: lru}, nil
+}
+
+// Purge is used to completely clear the cache.
+func (c *TSCache) Purge() {
+	c.lru.Purge()
+}
+
+// Add adds a value to the cache. Returns true if an eviction occurred.
+func (c *TSCache) Add(key, value interface{}) (evicted bool) {
+	evicted = c.lru.Add(key, value)
+	return
+}
+
+// Get looks up a key's value from the cache.
+func (c *TSCache) Get(key interface{}) (value interface{}, ok bool) {
+	return c.lru.Get(key)
+}
+
+// Contains checks if a key is in the cache, without updating the
+// recent-ness or deleting it for being stale.
+func (c *TSCache) Contains(key interface{}) bool {
+	return c.lru.Contains(key)
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *TSCache) Peek(key interface{}) (value interface{}, ok bool) {
+	return c.lru.Peek(key)
+}
+
+// ContainsOrAdd checks if a key is in the cache without updating the
+// recent-ness or deleting it for being stale, and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *TSCache) ContainsOrAdd(key, value interface{}) (ok, evicted bool) {
+	if c.lru.Contains(key) {
+		return true, false
+	}
+	return false, c.lru.Add(key, value)
+}
+
+// PeekOrAdd checks if a key is in the cache without updating the
+// recent-ness or deleting it for being stale, and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *TSCache) PeekOrAdd(key, value interface{}) (previous interface{}, ok, evicted bool) {
+	previous, ok = c.lru.Peek(key)
+	if ok {
+		return previous, true, false
+	}
+	return nil, false, c.lru.Add(key, value)
+}
+
+// Remove removes the provided key from the cache.
+func (c *TSCache) Remove(key interface{}) (present bool) {
+	return c.lru.Remove(key)
+}
+
+// Resize changes the cache size.
+func (c *TSCache) Resize(size int) (evicted int) {
+	c.lru.Resize(size)
+	return
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *TSCache) Keys() (ret []interface{}) {
+	return c.lru.Keys()
+}
+
+// Len returns the number of items in the cache.
+func (c *TSCache) Len() (ret int) {
+	return c.lru.Len()
+}

--- a/tslru/lru.go
+++ b/tslru/lru.go
@@ -217,7 +217,7 @@ func (c *LRU) Keys() []interface{} {
 	a := action{t: iterAction, o: make(chan interface{})}
 	c.ctl <- a
 
-	var ret = make([]interface{}, c.Len())
+	var ret = make([]interface{}, 0, c.Len())
 	for k := range a.o {
 		ret = append(ret, k)
 	}

--- a/tslru/lru.go
+++ b/tslru/lru.go
@@ -1,0 +1,231 @@
+// Package tslru provides thread safe LRU implementation based on build-in channel.
+package tslru
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+type actionType string
+
+const (
+	hitAction    actionType = "hit" // Get()
+	addAction    actionType = "add"
+	delAction    actionType = "del"
+	oldestAction actionType = "get_old"
+	iterAction   actionType = "iter"
+	purgeAction  actionType = "purge"
+)
+
+type action struct {
+	t   actionType
+	ele *entry
+
+	o1 chan interface{}
+	o2 chan *entry
+	o3 chan struct{}
+}
+
+// LRU implements a thread safe fixed size LRU cache
+type LRU struct {
+	mu        sync.RWMutex
+	limit     int32
+	evictList *list.List
+	items     map[interface{}]*entry
+	ctl       chan action
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key     interface{}
+	value   interface{}
+	element *list.Element
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU(size int) (*LRU, error) {
+	if size <= 0 {
+		return nil, errors.New("must provide a positive size")
+	}
+	c := &LRU{
+		limit:     int32(size),
+		evictList: list.New(),
+		ctl:       make(chan action, 1024),
+		items:     make(map[interface{}]*entry),
+	}
+	go c.work()
+	return c, nil
+}
+
+func (c *LRU) work() {
+	defer close(c.ctl)
+	for {
+		act := <-c.ctl
+		switch act.t {
+		case hitAction:
+			if ele := act.ele.element; ele != nil {
+				c.evictList.MoveToFront(ele)
+			}
+		case addAction:
+			limit := int(atomic.LoadInt32(&c.limit))
+			c.mu.Lock()
+			if len(c.items) > limit+500 {
+				ele := c.evictList.Back()
+				for len(c.items) > limit && ele != nil {
+					delete(c.items, ele.Value.(*entry).key)
+					ele2 := ele.Prev()
+					c.evictList.Remove(ele)
+					ele = ele2
+				}
+			}
+			c.mu.Unlock()
+			act.ele.element = c.evictList.PushFront(act.ele)
+		case delAction:
+			c.evictList.Remove(act.ele.element)
+		case oldestAction:
+			if ele := c.evictList.Back(); ele != nil {
+				act.o2 <- ele.Value.(*entry)
+			}
+		case iterAction:
+			for ele := c.evictList.Back(); ele != nil && ele != c.evictList.Front(); ele = ele.Prev() {
+				act.o1 <- ele.Value.(*entry).key
+			}
+			close(act.o1)
+		case purgeAction:
+			c.evictList.Init()
+			act.o3 <- struct{}{}
+		}
+	}
+}
+
+// Len Returns the number of items in the items.
+func (c *LRU) Len() int {
+	c.mu.RLock()
+	size := len(c.items)
+	c.mu.RUnlock()
+	return size
+}
+
+// Add adds a value to the items.  Returns true if an eviction occurred.
+func (c *LRU) Add(key, value interface{}) (evicted bool) {
+	ent := &entry{key: key, value: value}
+	c.mu.Lock()
+	c.items[key] = ent
+	evicted = len(c.items) > int(atomic.LoadInt32(&c.limit))
+	c.mu.Unlock()
+	c.ctl <- action{t: addAction, ele: ent}
+	return
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
+	c.mu.RLock()
+	ent, ok := c.items[key]
+	c.mu.RUnlock()
+	if ok {
+		select {
+		case c.ctl <- action{t: hitAction, ele: ent}:
+		default:
+			// log
+		}
+		return ent.value, true
+	}
+	return
+}
+
+// Contains checks if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *LRU) Contains(key interface{}) (ok bool) {
+	c.mu.RLock()
+	_, ok = c.items[key]
+	c.mu.RUnlock()
+	return ok
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+	c.mu.RLock()
+	ent, ok := c.items[key]
+	c.mu.RUnlock()
+	if ok {
+		return ent.value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU) Remove(key interface{}) (present bool) {
+	c.mu.Lock()
+	ent, ok := c.items[key]
+	if ok {
+		delete(c.items, key)
+		c.mu.Unlock()
+		c.ctl <- action{t: delAction, ele: ent}
+		return true
+	}
+	c.mu.Unlock()
+	return false
+}
+
+// RemoveOldest Removes the oldest entry from cache.
+func (c *LRU) RemoveOldest() (interface{}, interface{}, bool) {
+	if k, v, ok := c.GetOldest(); ok {
+		c.Remove(k)
+		return k, v, true
+	}
+	return nil, nil, false
+}
+
+// GetOldest Returns the oldest entry from the cache. #key, value, isFound
+func (c *LRU) GetOldest() (interface{}, interface{}, bool) {
+	a := action{t: oldestAction, o2: make(chan *entry)}
+	c.ctl <- a
+
+	if ent := <-a.o2; ent != nil {
+		return ent.key, ent.value, true
+	}
+	return nil, nil, false
+}
+
+// Keys Returns a slice of the keys in the cache, from oldest to newest.
+func (c *LRU) Keys() []interface{} {
+	a := action{t: iterAction, o1: make(chan interface{})}
+	c.ctl <- a
+
+	var ret = make([]interface{}, 0, c.Len())
+	for k := range a.o1 {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
+// Purge Clears all cache entries.
+func (c *LRU) Purge() {
+	c.mu.Lock()
+	c.items = make(map[interface{}]*entry)
+	c.mu.Unlock()
+
+	a := action{t: purgeAction, o3: make(chan struct{})}
+	c.ctl <- a
+	<-a.o3
+}
+
+// Resize cache, returning number evicted
+func (c *LRU) Resize(newSize int) int {
+	diff := newSize - int(atomic.LoadInt32(&c.limit))
+	atomic.StoreInt32(&c.limit, int32(newSize))
+
+	num := 0
+	for diff < 0 {
+		if _, _, ok := c.RemoveOldest(); !ok {
+			break
+		}
+		num++
+		diff++
+	}
+	return num
+}

--- a/tslru/lru.go
+++ b/tslru/lru.go
@@ -217,7 +217,7 @@ func (c *LRU) Keys() []interface{} {
 	a := action{t: iterAction, o: make(chan interface{})}
 	c.ctl <- a
 
-	var ret []interface{}
+	var ret = make([]interface{}, c.Len())
 	for k := range a.o {
 		ret = append(ret, k)
 	}

--- a/tslru/lru_test.go
+++ b/tslru/lru_test.go
@@ -1,0 +1,206 @@
+package tslru
+
+import "testing"
+
+func TestLRU(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+		}
+		evictCounter++
+	}
+	l, err := NewLRU(128, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	if evictCounter != 128 {
+		t.Fatalf("bad evict count: %v", evictCounter)
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		ok := l.Remove(i)
+		if !ok {
+			t.Fatalf("should be contained")
+		}
+		ok = l.Remove(i)
+		if ok {
+			t.Fatalf("should not be contained")
+		}
+		_, ok = l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Get(192) // expect 192 to be last key in l.Keys()
+
+	for i, k := range l.Keys() {
+		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+			t.Fatalf("out of order key: %v", k)
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
+	l, err := NewLRU(128, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	k, _, ok := l.GetOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != 128 {
+		t.Fatalf("bad: %v", k)
+	}
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != 128 {
+		t.Fatalf("bad: %v", k)
+	}
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k.(int) != 129 {
+		t.Fatalf("bad: %v", k)
+	}
+}
+
+// Test that Add returns true/false if an eviction occurred
+func TestLRU_Add(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		evictCounter++
+	}
+
+	l, err := NewLRU(1, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.Add(1, 1) == true || evictCounter != 0 {
+		t.Errorf("should not have an eviction")
+	}
+	if l.Add(2, 2) == false || evictCounter != 1 {
+		t.Errorf("should have an eviction")
+	}
+}
+
+// Test that Contains doesn't update recent-ness
+func TestLRU_Contains(t *testing.T) {
+	l, err := NewLRU(2, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// Test that Peek doesn't update recent-ness
+func TestLRU_Peek(t *testing.T) {
+	l, err := NewLRU(2, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}
+
+// Test that Resize can upsize and downsize
+func TestLRU_Resize(t *testing.T) {
+	onEvictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		onEvictCounter++
+	}
+	l, err := NewLRU(2, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Downsize
+	l.Add(1, 1)
+	l.Add(2, 2)
+	evicted := l.Resize(1)
+	if evicted != 1 {
+		t.Errorf("1 element should have been evicted: %v", evicted)
+	}
+	if onEvictCounter != 1 {
+		t.Errorf("onEvicted should have been called 1 time: %v", onEvictCounter)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Element 1 should have been evicted")
+	}
+
+	// Upsize
+	evicted = l.Resize(2)
+	if evicted != 0 {
+		t.Errorf("0 elements should have been evicted: %v", evicted)
+	}
+
+	l.Add(4, 4)
+	if !l.Contains(3) || !l.Contains(4) {
+		t.Errorf("Cache should have contained 2 elements")
+	}
+}

--- a/tslru/lru_test.go
+++ b/tslru/lru_test.go
@@ -1,16 +1,12 @@
 package tslru
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestLRU(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		if k != v {
-			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
-		}
-		evictCounter++
-	}
-	l, err := NewLRU(128, onEvicted)
+
+	l, err := NewLRU(128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -20,10 +16,6 @@ func TestLRU(t *testing.T) {
 	}
 	if l.Len() != 128 {
 		t.Fatalf("bad len: %v", l.Len())
-	}
-
-	if evictCounter != 128 {
-		t.Fatalf("bad evict count: %v", evictCounter)
 	}
 
 	for i, k := range l.Keys() {
@@ -76,7 +68,7 @@ func TestLRU(t *testing.T) {
 }
 
 func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
-	l, err := NewLRU(128, nil)
+	l, err := NewLRU(128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -110,27 +102,23 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 
 // Test that Add returns true/false if an eviction occurred
 func TestLRU_Add(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		evictCounter++
-	}
 
-	l, err := NewLRU(1, onEvicted)
+	l, err := NewLRU(1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if l.Add(1, 1) == true || evictCounter != 0 {
+	if l.Add(1, 1) == true {
 		t.Errorf("should not have an eviction")
 	}
-	if l.Add(2, 2) == false || evictCounter != 1 {
+	if l.Add(2, 2) == false {
 		t.Errorf("should have an eviction")
 	}
 }
 
 // Test that Contains doesn't update recent-ness
 func TestLRU_Contains(t *testing.T) {
-	l, err := NewLRU(2, nil)
+	l, err := NewLRU(2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +137,7 @@ func TestLRU_Contains(t *testing.T) {
 
 // Test that Peek doesn't update recent-ness
 func TestLRU_Peek(t *testing.T) {
-	l, err := NewLRU(2, nil)
+	l, err := NewLRU(2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -168,11 +156,8 @@ func TestLRU_Peek(t *testing.T) {
 
 // Test that Resize can upsize and downsize
 func TestLRU_Resize(t *testing.T) {
-	onEvictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		onEvictCounter++
-	}
-	l, err := NewLRU(2, onEvicted)
+
+	l, err := NewLRU(2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -183,9 +168,6 @@ func TestLRU_Resize(t *testing.T) {
 	evicted := l.Resize(1)
 	if evicted != 1 {
 		t.Errorf("1 element should have been evicted: %v", evicted)
-	}
-	if onEvictCounter != 1 {
-		t.Errorf("onEvicted should have been called 1 time: %v", onEvictCounter)
 	}
 
 	l.Add(3, 3)

--- a/tslru_test.go
+++ b/tslru_test.go
@@ -1,0 +1,272 @@
+package lru
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkLRU_Rand(b *testing.B) {
+	l, err := NewTSCache(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		trace[i] = rand.Int63() % 32768
+	}
+
+	b.ResetTimer()
+
+	var hit, miss int
+	for i := 0; i < 2*b.N; i++ {
+		if i%2 == 0 {
+			l.Add(trace[i], trace[i])
+		} else {
+			_, ok := l.Get(trace[i])
+			if ok {
+				hit++
+			} else {
+				miss++
+			}
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func BenchmarkLRU_Freq(b *testing.B) {
+	l, err := NewTSCache(8192)
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	trace := make([]int64, b.N*2)
+	for i := 0; i < b.N*2; i++ {
+		if i%2 == 0 {
+			trace[i] = rand.Int63() % 16384
+		} else {
+			trace[i] = rand.Int63() % 32768
+		}
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Add(trace[i], trace[i])
+	}
+	var hit, miss int
+	for i := 0; i < b.N; i++ {
+		_, ok := l.Get(trace[i])
+		if ok {
+			hit++
+		} else {
+			miss++
+		}
+	}
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+}
+
+func TestLRU(t *testing.T) {
+	l, err := NewTSCache(128)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Get(192) // expect 192 to be last key in l.Keys()
+
+	for i, k := range l.Keys() {
+		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+			t.Fatalf("out of order key: %v", k)
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+// test that Add returns true/false if an eviction occurred
+func TestLRUAdd(t *testing.T) {
+
+	l, err := NewTSCache(1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.Add(1, 1) == true {
+		t.Errorf("should not have an eviction")
+	}
+	if l.Add(2, 2) == false {
+		t.Errorf("should have an eviction")
+	}
+}
+
+// test that Contains doesn't update recent-ness
+func TestLRUContains(t *testing.T) {
+	l, err := NewTSCache(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// test that ContainsOrAdd doesn't update recent-ness
+func TestLRUContainsOrAdd(t *testing.T) {
+	l, err := NewTSCache(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	contains, evict := l.ContainsOrAdd(1, 1)
+	if !contains {
+		t.Errorf("1 should be contained")
+	}
+	if evict {
+		t.Errorf("nothing should be evicted here")
+	}
+
+	l.Add(3, 3)
+	contains, evict = l.ContainsOrAdd(1, 1)
+	if contains {
+		t.Errorf("1 should not have been contained")
+	}
+	if !evict {
+		t.Errorf("an eviction should have occurred")
+	}
+	if !l.Contains(1) {
+		t.Errorf("now 1 should be contained")
+	}
+}
+
+// test that PeekOrAdd doesn't update recent-ness
+func TestLRUPeekOrAdd(t *testing.T) {
+	l, err := NewTSCache(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	previous, contains, evict := l.PeekOrAdd(1, 1)
+	if !contains {
+		t.Errorf("1 should be contained")
+	}
+	if evict {
+		t.Errorf("nothing should be evicted here")
+	}
+	if previous != 1 {
+		t.Errorf("previous is not equal to 1")
+	}
+
+	l.Add(3, 3)
+	contains, evict = l.ContainsOrAdd(1, 1)
+	if contains {
+		t.Errorf("1 should not have been contained")
+	}
+	if !evict {
+		t.Errorf("an eviction should have occurred")
+	}
+	if !l.Contains(1) {
+		t.Errorf("now 1 should be contained")
+	}
+}
+
+// test that Peek doesn't update recent-ness
+func TestLRUPeek(t *testing.T) {
+	l, err := NewTSCache(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}
+
+// test that Resize can upsize and downsize
+func TestLRUResize(t *testing.T) {
+
+	l, err := NewTSCache(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Downsize
+	l.Add(1, 1)
+	l.Add(2, 2)
+	evicted := l.Resize(1)
+	if evicted != 1 {
+		t.Errorf("1 element should have been evicted: %v", evicted)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Element 1 should have been evicted")
+	}
+
+	// Upsize
+	evicted = l.Resize(2)
+	if evicted != 0 {
+		t.Errorf("0 elements should have been evicted: %v", evicted)
+	}
+
+	l.Add(4, 4)
+	if !l.Contains(3) || !l.Contains(4) {
+		t.Errorf("Cache should have contained 2 elements")
+	}
+}

--- a/tslru_test.go
+++ b/tslru_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func BenchmarkLRU_Rand(b *testing.B) {
+func BenchmarkTSLRU_Rand(b *testing.B) {
 	l, err := NewTSCache(8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
@@ -34,7 +34,7 @@ func BenchmarkLRU_Rand(b *testing.B) {
 	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
 }
 
-func BenchmarkLRU_Freq(b *testing.B) {
+func BenchmarkTSLRU_Freq(b *testing.B) {
 	l, err := NewTSCache(8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
@@ -66,7 +66,7 @@ func BenchmarkLRU_Freq(b *testing.B) {
 	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
 }
 
-func TestLRU(t *testing.T) {
+func TestTSLRU(t *testing.T) {
 	l, err := NewTSCache(128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -122,7 +122,7 @@ func TestLRU(t *testing.T) {
 }
 
 // test that Add returns true/false if an eviction occurred
-func TestLRUAdd(t *testing.T) {
+func TestTSLRUAdd(t *testing.T) {
 
 	l, err := NewTSCache(1)
 	if err != nil {
@@ -138,7 +138,7 @@ func TestLRUAdd(t *testing.T) {
 }
 
 // test that Contains doesn't update recent-ness
-func TestLRUContains(t *testing.T) {
+func TestTSLRUContains(t *testing.T) {
 	l, err := NewTSCache(2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -157,7 +157,7 @@ func TestLRUContains(t *testing.T) {
 }
 
 // test that ContainsOrAdd doesn't update recent-ness
-func TestLRUContainsOrAdd(t *testing.T) {
+func TestTSLRUContainsOrAdd(t *testing.T) {
 	l, err := NewTSCache(2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -187,7 +187,7 @@ func TestLRUContainsOrAdd(t *testing.T) {
 }
 
 // test that PeekOrAdd doesn't update recent-ness
-func TestLRUPeekOrAdd(t *testing.T) {
+func TestTSLRUPeekOrAdd(t *testing.T) {
 	l, err := NewTSCache(2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -220,7 +220,7 @@ func TestLRUPeekOrAdd(t *testing.T) {
 }
 
 // test that Peek doesn't update recent-ness
-func TestLRUPeek(t *testing.T) {
+func TestTSLRUPeek(t *testing.T) {
 	l, err := NewTSCache(2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -239,7 +239,7 @@ func TestLRUPeek(t *testing.T) {
 }
 
 // test that Resize can upsize and downsize
-func TestLRUResize(t *testing.T) {
+func TestTSLRUResize(t *testing.T) {
 
 	l, err := NewTSCache(2)
 	if err != nil {


### PR DESCRIPTION
Tslru's concurrent get() performance exceeds sync.RWMutex and simplelru