### PR TITLE
add Values() method to get cache values

### DIFF
--- a/2q.go
+++ b/2q.go
@@ -178,6 +178,16 @@ func (c *TwoQueueCache) Keys() []interface{} {
 	return append(k1, k2...)
 }
 
+// Values returns a slice of the values in the cache.
+// The frequently used values are first in the returned slice.
+func (c *TwoQueueCache) Values() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	v1 := c.frequent.Values()
+	v2 := c.recent.Values()
+	return append(v1, v2...)
+}
+
 // Remove removes the provided key from the cache.
 func (c *TwoQueueCache) Remove(key interface{}) {
 	c.lock.Lock()

--- a/2q_test.go
+++ b/2q_test.go
@@ -238,6 +238,11 @@ func Test2Q(t *testing.T) {
 			t.Fatalf("bad key: %v", k)
 		}
 	}
+	for i, v := range l.Values() {
+		if v != i+128 {
+			t.Fatalf("bad key: %v", v)
+		}
+	}
 	for i := 0; i < 128; i++ {
 		_, ok := l.Get(i)
 		if ok {

--- a/arc.go
+++ b/arc.go
@@ -208,6 +208,15 @@ func (c *ARCCache) Keys() []interface{} {
 	return append(k1, k2...)
 }
 
+// Values returns all the cached values
+func (c *ARCCache) Values() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	v1 := c.t1.Values()
+	v2 := c.t2.Values()
+	return append(v1, v2...)
+}
+
 // Remove is used to purge a key from the cache
 func (c *ARCCache) Remove(key interface{}) {
 	c.lock.Lock()

--- a/arc_test.go
+++ b/arc_test.go
@@ -309,6 +309,11 @@ func TestARC(t *testing.T) {
 			t.Fatalf("bad key: %v", k)
 		}
 	}
+	for i, v := range l.Values() {
+		if v != i+128 {
+			t.Fatalf("bad value: %v", v)
+		}
+	}
 	for i := 0; i < 128; i++ {
 		_, ok := l.Get(i)
 		if ok {

--- a/lru.go
+++ b/lru.go
@@ -222,6 +222,14 @@ func (c *Cache) Keys() []interface{} {
 	return keys
 }
 
+// Values returns a slice of the values in the cache, from oldest to newest.
+func (c *Cache) Values() []interface{} {
+	c.lock.RLock()
+	values := c.lru.Values()
+	c.lock.RUnlock()
+	return values
+}
+
 // Len returns the number of items in the cache.
 func (c *Cache) Len() int {
 	c.lock.RLock()

--- a/lru_test.go
+++ b/lru_test.go
@@ -95,6 +95,11 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("bad key: %v", k)
 		}
 	}
+	for i, v := range l.Values() {
+		if v != i+128 {
+			t.Fatalf("bad value: %v", v)
+		}
+	}
 	for i := 0; i < 128; i++ {
 		_, ok := l.Get(i)
 		if ok {

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -140,6 +140,17 @@ func (c *LRU) Keys() []interface{} {
 	return keys
 }
 
+// Values returns a slice of the values in the cache, from oldest to newest.
+func (c *LRU) Values() []interface{} {
+	values := make([]interface{}, len(c.items))
+	i := 0
+	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
+		values[i] = ent.Value.(*entry).value
+		i++
+	}
+	return values
+}
+
 // Len returns the number of items in the cache.
 func (c *LRU) Len() int {
 	return c.evictList.Len()

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -29,6 +29,9 @@ type LRUCache interface {
 	// Returns a slice of the keys in the cache, from oldest to newest.
 	Keys() []interface{}
 
+	// Values returns a slice of the values in the cache, from oldest to newest.
+	Values() []interface{}
+
 	// Returns the number of items in the cache.
 	Len() int
 

--- a/simplelru/lru_test.go
+++ b/simplelru/lru_test.go
@@ -31,6 +31,11 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("bad key: %v", k)
 		}
 	}
+	for i, v := range l.Values() {
+		if v != i+128 {
+			t.Fatalf("bad value: %v", v)
+		}
+	}
 	for i := 0; i < 128; i++ {
 		_, ok := l.Get(i)
 		if ok {


### PR DESCRIPTION
Hi @jefferai !

All the current cache implementations export the `Keys()` method which returns all the keys in the cache. 

In some cases, like cache testing, you need to know all the cache values. You can do this via `Keys() + Get()` operation, but this is not an atomic operation.

So I present `Values()` which returns all the cache values in a similar way to `Keys()`. Please consider adding this method to the caches.