### PR TITLE
Added AddOrUpdate method to lru

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -85,6 +85,28 @@ func (c *Cache) Add(key, value interface{}) (evicted bool) {
 	return
 }
 
+// AddOrUpdate adds a value to the cache or if key already exists, it executes an update function. Returns true if an eviction occurred.
+func (c *Cache) AddOrUpdate(key, value interface{}, update func(v1, v2 interface{}) interface{}) (evicted bool) {
+	var k, v interface{}
+	c.lock.Lock()
+	oldValue, found := c.lru.Get(key)
+
+	if found {
+		value = update(oldValue, value)
+	}
+
+	evicted = c.lru.Add(key, value)
+	if c.onEvictedCB != nil && evicted {
+		k, v = c.evictedKeys[0], c.evictedVals[0]
+		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && evicted {
+		c.onEvictedCB(k, v)
+	}
+	return
+}
+
 // Get looks up a key's value from the cache.
 func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
 	c.lock.Lock()

--- a/lru_test.go
+++ b/lru_test.go
@@ -291,3 +291,36 @@ func TestLRUResize(t *testing.T) {
 		t.Errorf("Cache should have contained 2 elements")
 	}
 }
+
+// test that AddOrUpdate calls the update method
+func TestLRUAddOrUpdate(t *testing.T) {
+	l, err := New(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	value1 := []string{"some_value"}
+	value2 := []string{"some_value_2"}
+
+	l.Add(1, value1)
+	l.AddOrUpdate(1, value2, func(v1, v2 interface{}) interface{} {
+		slice1 := v1.([]string)
+		slice2 := v2.([]string)
+		return append(slice1, slice2...)
+	})
+
+	retrieved, ok := l.Get(1)
+	if !ok {
+		t.Fatalf("Cache should contain the element")
+	}
+	retrievedSlice := retrieved.([]string)
+	if len(retrievedSlice) != 2 {
+		t.Fatalf("The retrieved slice should contain 2 elements")
+	}
+	if retrievedSlice[0] != "some_value" {
+		t.Fatalf("The first element should be some_value")
+	}
+	if retrievedSlice[1] != "some_value_2" {
+		t.Fatalf("The second element should be some_value_2")
+	}
+}


### PR DESCRIPTION
It behaves similar to the standard Add method with the difference
that it can also take an update method that will be performed
in case the key already exists.

For example:

```
value1 := []string{"some_value"}
value2 := []string{"some_value_2"}

l.Add(1, value1)
l.AddOrUpdate(1, value2, func(v1, v2 interface{}) interface{} {
	slice1 := v1.([]string)
	slice2 := v2.([]string)
	return append(slice1, slice2...)
})

```
Then `l.Get(1)` will result to
`[]string{"some_value", "some_value_2"}`