### PR TITLE
Golang 1.18: implement generic LRU interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _testmain.go
 
 *.exe
 *.test
+.idea

--- a/2q.go
+++ b/2q.go
@@ -85,7 +85,7 @@ func New2QParams(size int, recentRatio, ghostRatio float64) (*TwoQueueCache, err
 }
 
 // Get looks up a key's value from the cache.
-func (c *TwoQueueCache) Get(key interface{}) (value interface{}, ok bool) {
+func (c *TwoQueueCache) Get(key any) (value any, ok bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -107,7 +107,7 @@ func (c *TwoQueueCache) Get(key interface{}) (value interface{}, ok bool) {
 }
 
 // Add adds a value to the cache.
-func (c *TwoQueueCache) Add(key, value interface{}) {
+func (c *TwoQueueCache) Add(key, value any) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -170,7 +170,7 @@ func (c *TwoQueueCache) Len() int {
 
 // Keys returns a slice of the keys in the cache.
 // The frequently used keys are first in the returned slice.
-func (c *TwoQueueCache) Keys() []interface{} {
+func (c *TwoQueueCache) Keys() []any {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	k1 := c.frequent.Keys()
@@ -179,7 +179,7 @@ func (c *TwoQueueCache) Keys() []interface{} {
 }
 
 // Remove removes the provided key from the cache.
-func (c *TwoQueueCache) Remove(key interface{}) {
+func (c *TwoQueueCache) Remove(key any) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.frequent.Remove(key) {
@@ -204,7 +204,7 @@ func (c *TwoQueueCache) Purge() {
 
 // Contains is used to check if the cache contains a key
 // without updating recency or frequency.
-func (c *TwoQueueCache) Contains(key interface{}) bool {
+func (c *TwoQueueCache) Contains(key any) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.frequent.Contains(key) || c.recent.Contains(key)
@@ -212,7 +212,7 @@ func (c *TwoQueueCache) Contains(key interface{}) bool {
 
 // Peek is used to inspect the cache value of a key
 // without updating recency or frequency.
-func (c *TwoQueueCache) Peek(key interface{}) (value interface{}, ok bool) {
+func (c *TwoQueueCache) Peek(key any) (value any, ok bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if val, ok := c.frequent.Peek(key); ok {

--- a/2q.go
+++ b/2q.go
@@ -26,25 +26,25 @@ const (
 // computationally about 2x the cost, and adds some metadata over
 // head. The ARCCache is similar, but does not require setting any
 // parameters.
-type TwoQueueCache struct {
+type TwoQueueCache[K comparable] struct {
 	size       int
 	recentSize int
 
-	recent      simplelru.LRUCache
-	frequent    simplelru.LRUCache
-	recentEvict simplelru.LRUCache
+	recent      simplelru.LRUCache[K]
+	frequent    simplelru.LRUCache[K]
+	recentEvict simplelru.LRUCache[K]
 	lock        sync.RWMutex
 }
 
 // New2Q creates a new TwoQueueCache using the default
 // values for the parameters.
-func New2Q(size int) (*TwoQueueCache, error) {
-	return New2QParams(size, Default2QRecentRatio, Default2QGhostEntries)
+func New2Q[K comparable](size int) (*TwoQueueCache[K], error) {
+	return New2QParams[K](size, Default2QRecentRatio, Default2QGhostEntries)
 }
 
 // New2QParams creates a new TwoQueueCache using the provided
 // parameter values.
-func New2QParams(size int, recentRatio, ghostRatio float64) (*TwoQueueCache, error) {
+func New2QParams[K comparable](size int, recentRatio, ghostRatio float64) (*TwoQueueCache[K], error) {
 	if size <= 0 {
 		return nil, fmt.Errorf("invalid size")
 	}
@@ -60,21 +60,21 @@ func New2QParams(size int, recentRatio, ghostRatio float64) (*TwoQueueCache, err
 	evictSize := int(float64(size) * ghostRatio)
 
 	// Allocate the LRUs
-	recent, err := simplelru.NewLRU(size, nil)
+	recent, err := simplelru.NewLRU[K](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	frequent, err := simplelru.NewLRU(size, nil)
+	frequent, err := simplelru.NewLRU[K](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	recentEvict, err := simplelru.NewLRU(evictSize, nil)
+	recentEvict, err := simplelru.NewLRU[K](evictSize, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize the cache
-	c := &TwoQueueCache{
+	c := &TwoQueueCache[K]{
 		size:        size,
 		recentSize:  recentSize,
 		recent:      recent,
@@ -85,7 +85,7 @@ func New2QParams(size int, recentRatio, ghostRatio float64) (*TwoQueueCache, err
 }
 
 // Get looks up a key's value from the cache.
-func (c *TwoQueueCache) Get(key any) (value any, ok bool) {
+func (c *TwoQueueCache[K]) Get(key K) (value any, ok bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -107,7 +107,7 @@ func (c *TwoQueueCache) Get(key any) (value any, ok bool) {
 }
 
 // Add adds a value to the cache.
-func (c *TwoQueueCache) Add(key, value any) {
+func (c *TwoQueueCache[K]) Add(key K, value any) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -141,7 +141,7 @@ func (c *TwoQueueCache) Add(key, value any) {
 }
 
 // ensureSpace is used to ensure we have space in the cache
-func (c *TwoQueueCache) ensureSpace(recentEvict bool) {
+func (c *TwoQueueCache[K]) ensureSpace(recentEvict bool) {
 	// If we have space, nothing to do
 	recentLen := c.recent.Len()
 	freqLen := c.frequent.Len()
@@ -162,7 +162,7 @@ func (c *TwoQueueCache) ensureSpace(recentEvict bool) {
 }
 
 // Len returns the number of items in the cache.
-func (c *TwoQueueCache) Len() int {
+func (c *TwoQueueCache[K]) Len() int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.recent.Len() + c.frequent.Len()
@@ -170,7 +170,7 @@ func (c *TwoQueueCache) Len() int {
 
 // Keys returns a slice of the keys in the cache.
 // The frequently used keys are first in the returned slice.
-func (c *TwoQueueCache) Keys() []any {
+func (c *TwoQueueCache[K]) Keys() []K {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	k1 := c.frequent.Keys()
@@ -179,7 +179,7 @@ func (c *TwoQueueCache) Keys() []any {
 }
 
 // Remove removes the provided key from the cache.
-func (c *TwoQueueCache) Remove(key any) {
+func (c *TwoQueueCache[K]) Remove(key K) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.frequent.Remove(key) {
@@ -194,7 +194,7 @@ func (c *TwoQueueCache) Remove(key any) {
 }
 
 // Purge is used to completely clear the cache.
-func (c *TwoQueueCache) Purge() {
+func (c *TwoQueueCache[K]) Purge() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.recent.Purge()
@@ -204,7 +204,7 @@ func (c *TwoQueueCache) Purge() {
 
 // Contains is used to check if the cache contains a key
 // without updating recency or frequency.
-func (c *TwoQueueCache) Contains(key any) bool {
+func (c *TwoQueueCache[K]) Contains(key K) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.frequent.Contains(key) || c.recent.Contains(key)
@@ -212,7 +212,7 @@ func (c *TwoQueueCache) Contains(key any) bool {
 
 // Peek is used to inspect the cache value of a key
 // without updating recency or frequency.
-func (c *TwoQueueCache) Peek(key any) (value any, ok bool) {
+func (c *TwoQueueCache[K]) Peek(key K) (value any, ok bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if val, ok := c.frequent.Peek(key); ok {

--- a/2q_test.go
+++ b/2q_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Benchmark2Q_Rand(b *testing.B) {
-	l, err := New2Q(8192)
+	l, err := New2Q[int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -35,7 +35,7 @@ func Benchmark2Q_Rand(b *testing.B) {
 }
 
 func Benchmark2Q_Freq(b *testing.B) {
-	l, err := New2Q(8192)
+	l, err := New2Q[int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -68,7 +68,7 @@ func Benchmark2Q_Freq(b *testing.B) {
 
 func Test2Q_RandomOps(t *testing.T) {
 	size := 128
-	l, err := New2Q(128)
+	l, err := New2Q[int64](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -94,7 +94,7 @@ func Test2Q_RandomOps(t *testing.T) {
 }
 
 func Test2Q_Get_RecentToFrequent(t *testing.T) {
-	l, err := New2Q(128)
+	l, err := New2Q[int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -140,7 +140,7 @@ func Test2Q_Get_RecentToFrequent(t *testing.T) {
 }
 
 func Test2Q_Add_RecentToFrequent(t *testing.T) {
-	l, err := New2Q(128)
+	l, err := New2Q[int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -174,7 +174,7 @@ func Test2Q_Add_RecentToFrequent(t *testing.T) {
 }
 
 func Test2Q_Add_RecentEvict(t *testing.T) {
-	l, err := New2Q(4)
+	l, err := New2Q[int](4)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -221,7 +221,7 @@ func Test2Q_Add_RecentEvict(t *testing.T) {
 }
 
 func Test2Q(t *testing.T) {
-	l, err := New2Q(128)
+	l, err := New2Q[int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -269,7 +269,7 @@ func Test2Q(t *testing.T) {
 
 // Test that Contains doesn't update recent-ness
 func Test2Q_Contains(t *testing.T) {
-	l, err := New2Q(2)
+	l, err := New2Q[int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -288,7 +288,7 @@ func Test2Q_Contains(t *testing.T) {
 
 // Test that Peek doesn't update recent-ness
 func Test2Q_Peek(t *testing.T) {
-	l, err := New2Q(2)
+	l, err := New2Q[int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/2q_test.go
+++ b/2q_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Benchmark2Q_Rand(b *testing.B) {
-	l, err := New2Q[int64](8192)
+	l, err := New2Q[int64, int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -35,7 +35,7 @@ func Benchmark2Q_Rand(b *testing.B) {
 }
 
 func Benchmark2Q_Freq(b *testing.B) {
-	l, err := New2Q[int64](8192)
+	l, err := New2Q[int64, int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -68,7 +68,7 @@ func Benchmark2Q_Freq(b *testing.B) {
 
 func Test2Q_RandomOps(t *testing.T) {
 	size := 128
-	l, err := New2Q[int64](128)
+	l, err := New2Q[int64, int64](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -94,7 +94,7 @@ func Test2Q_RandomOps(t *testing.T) {
 }
 
 func Test2Q_Get_RecentToFrequent(t *testing.T) {
-	l, err := New2Q[int](128)
+	l, err := New2Q[int, int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -140,7 +140,7 @@ func Test2Q_Get_RecentToFrequent(t *testing.T) {
 }
 
 func Test2Q_Add_RecentToFrequent(t *testing.T) {
-	l, err := New2Q[int](128)
+	l, err := New2Q[int, int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -174,7 +174,7 @@ func Test2Q_Add_RecentToFrequent(t *testing.T) {
 }
 
 func Test2Q_Add_RecentEvict(t *testing.T) {
-	l, err := New2Q[int](4)
+	l, err := New2Q[int, int](4)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -221,7 +221,7 @@ func Test2Q_Add_RecentEvict(t *testing.T) {
 }
 
 func Test2Q(t *testing.T) {
-	l, err := New2Q[int](128)
+	l, err := New2Q[int, int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -269,7 +269,7 @@ func Test2Q(t *testing.T) {
 
 // Test that Contains doesn't update recent-ness
 func Test2Q_Contains(t *testing.T) {
-	l, err := New2Q[int](2)
+	l, err := New2Q[int, int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -288,7 +288,7 @@ func Test2Q_Contains(t *testing.T) {
 
 // Test that Peek doesn't update recent-ness
 func Test2Q_Peek(t *testing.T) {
-	l, err := New2Q[int](2)
+	l, err := New2Q[int, int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/arc.go
+++ b/arc.go
@@ -60,7 +60,7 @@ func NewARC(size int) (*ARCCache, error) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *ARCCache) Get(key interface{}) (value interface{}, ok bool) {
+func (c *ARCCache) Get(key any) (value any, ok bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -82,7 +82,7 @@ func (c *ARCCache) Get(key interface{}) (value interface{}, ok bool) {
 }
 
 // Add adds a value to the cache.
-func (c *ARCCache) Add(key, value interface{}) {
+func (c *ARCCache) Add(key, value any) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -200,7 +200,7 @@ func (c *ARCCache) Len() int {
 }
 
 // Keys returns all the cached keys
-func (c *ARCCache) Keys() []interface{} {
+func (c *ARCCache) Keys() []any {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	k1 := c.t1.Keys()
@@ -209,7 +209,7 @@ func (c *ARCCache) Keys() []interface{} {
 }
 
 // Remove is used to purge a key from the cache
-func (c *ARCCache) Remove(key interface{}) {
+func (c *ARCCache) Remove(key any) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.t1.Remove(key) {
@@ -238,7 +238,7 @@ func (c *ARCCache) Purge() {
 
 // Contains is used to check if the cache contains a key
 // without updating recency or frequency.
-func (c *ARCCache) Contains(key interface{}) bool {
+func (c *ARCCache) Contains(key any) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.t1.Contains(key) || c.t2.Contains(key)
@@ -246,7 +246,7 @@ func (c *ARCCache) Contains(key interface{}) bool {
 
 // Peek is used to inspect the cache value of a key
 // without updating recency or frequency.
-func (c *ARCCache) Peek(key interface{}) (value interface{}, ok bool) {
+func (c *ARCCache) Peek(key any) (value any, ok bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if val, ok := c.t1.Peek(key); ok {

--- a/arc.go
+++ b/arc.go
@@ -14,41 +14,41 @@ import (
 // it is roughly 2x the cost, and the extra memory overhead is linear
 // with the size of the cache. ARC has been patented by IBM, but is
 // similar to the TwoQueueCache (2Q) which requires setting parameters.
-type ARCCache struct {
+type ARCCache[K comparable] struct {
 	size int // Size is the total capacity of the cache
 	p    int // P is the dynamic preference towards T1 or T2
 
-	t1 simplelru.LRUCache // T1 is the LRU for recently accessed items
-	b1 simplelru.LRUCache // B1 is the LRU for evictions from t1
+	t1 simplelru.LRUCache[K] // T1 is the LRU for recently accessed items
+	b1 simplelru.LRUCache[K] // B1 is the LRU for evictions from t1
 
-	t2 simplelru.LRUCache // T2 is the LRU for frequently accessed items
-	b2 simplelru.LRUCache // B2 is the LRU for evictions from t2
+	t2 simplelru.LRUCache[K] // T2 is the LRU for frequently accessed items
+	b2 simplelru.LRUCache[K] // B2 is the LRU for evictions from t2
 
 	lock sync.RWMutex
 }
 
 // NewARC creates an ARC of the given size
-func NewARC(size int) (*ARCCache, error) {
+func NewARC[K comparable](size int) (*ARCCache[K], error) {
 	// Create the sub LRUs
-	b1, err := simplelru.NewLRU(size, nil)
+	b1, err := simplelru.NewLRU[K](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	b2, err := simplelru.NewLRU(size, nil)
+	b2, err := simplelru.NewLRU[K](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	t1, err := simplelru.NewLRU(size, nil)
+	t1, err := simplelru.NewLRU[K](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	t2, err := simplelru.NewLRU(size, nil)
+	t2, err := simplelru.NewLRU[K](size, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize the ARC
-	c := &ARCCache{
+	c := &ARCCache[K]{
 		size: size,
 		p:    0,
 		t1:   t1,
@@ -60,7 +60,7 @@ func NewARC(size int) (*ARCCache, error) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *ARCCache) Get(key any) (value any, ok bool) {
+func (c *ARCCache[K]) Get(key K) (value any, ok bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -82,7 +82,7 @@ func (c *ARCCache) Get(key any) (value any, ok bool) {
 }
 
 // Add adds a value to the cache.
-func (c *ARCCache) Add(key, value any) {
+func (c *ARCCache[K]) Add(key K, value any) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -177,7 +177,7 @@ func (c *ARCCache) Add(key, value any) {
 
 // replace is used to adaptively evict from either T1 or T2
 // based on the current learned value of P
-func (c *ARCCache) replace(b2ContainsKey bool) {
+func (c *ARCCache[K]) replace(b2ContainsKey bool) {
 	t1Len := c.t1.Len()
 	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
 		k, _, ok := c.t1.RemoveOldest()
@@ -193,14 +193,14 @@ func (c *ARCCache) replace(b2ContainsKey bool) {
 }
 
 // Len returns the number of cached entries
-func (c *ARCCache) Len() int {
+func (c *ARCCache[K]) Len() int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.t1.Len() + c.t2.Len()
 }
 
 // Keys returns all the cached keys
-func (c *ARCCache) Keys() []any {
+func (c *ARCCache[K]) Keys() []K {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	k1 := c.t1.Keys()
@@ -209,7 +209,7 @@ func (c *ARCCache) Keys() []any {
 }
 
 // Remove is used to purge a key from the cache
-func (c *ARCCache) Remove(key any) {
+func (c *ARCCache[K]) Remove(key K) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.t1.Remove(key) {
@@ -227,7 +227,7 @@ func (c *ARCCache) Remove(key any) {
 }
 
 // Purge is used to clear the cache
-func (c *ARCCache) Purge() {
+func (c *ARCCache[K]) Purge() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.t1.Purge()
@@ -238,7 +238,7 @@ func (c *ARCCache) Purge() {
 
 // Contains is used to check if the cache contains a key
 // without updating recency or frequency.
-func (c *ARCCache) Contains(key any) bool {
+func (c *ARCCache[K]) Contains(key K) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.t1.Contains(key) || c.t2.Contains(key)
@@ -246,7 +246,7 @@ func (c *ARCCache) Contains(key any) bool {
 
 // Peek is used to inspect the cache value of a key
 // without updating recency or frequency.
-func (c *ARCCache) Peek(key any) (value any, ok bool) {
+func (c *ARCCache[K]) Peek(key K) (value any, ok bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if val, ok := c.t1.Peek(key); ok {

--- a/arc.go
+++ b/arc.go
@@ -14,41 +14,41 @@ import (
 // it is roughly 2x the cost, and the extra memory overhead is linear
 // with the size of the cache. ARC has been patented by IBM, but is
 // similar to the TwoQueueCache (2Q) which requires setting parameters.
-type ARCCache[K comparable] struct {
+type ARCCache[K comparable, V any] struct {
 	size int // Size is the total capacity of the cache
 	p    int // P is the dynamic preference towards T1 or T2
 
-	t1 simplelru.LRUCache[K] // T1 is the LRU for recently accessed items
-	b1 simplelru.LRUCache[K] // B1 is the LRU for evictions from t1
+	t1 simplelru.LRUCache[K, V] // T1 is the LRU for recently accessed items
+	b1 simplelru.LRUCache[K, V] // B1 is the LRU for evictions from t1
 
-	t2 simplelru.LRUCache[K] // T2 is the LRU for frequently accessed items
-	b2 simplelru.LRUCache[K] // B2 is the LRU for evictions from t2
+	t2 simplelru.LRUCache[K, V] // T2 is the LRU for frequently accessed items
+	b2 simplelru.LRUCache[K, V] // B2 is the LRU for evictions from t2
 
 	lock sync.RWMutex
 }
 
 // NewARC creates an ARC of the given size
-func NewARC[K comparable](size int) (*ARCCache[K], error) {
+func NewARC[K comparable, V any](size int) (*ARCCache[K, V], error) {
 	// Create the sub LRUs
-	b1, err := simplelru.NewLRU[K](size, nil)
+	b1, err := simplelru.NewLRU[K, V](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	b2, err := simplelru.NewLRU[K](size, nil)
+	b2, err := simplelru.NewLRU[K, V](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	t1, err := simplelru.NewLRU[K](size, nil)
+	t1, err := simplelru.NewLRU[K, V](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	t2, err := simplelru.NewLRU[K](size, nil)
+	t2, err := simplelru.NewLRU[K, V](size, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize the ARC
-	c := &ARCCache[K]{
+	c := &ARCCache[K, V]{
 		size: size,
 		p:    0,
 		t1:   t1,
@@ -60,7 +60,7 @@ func NewARC[K comparable](size int) (*ARCCache[K], error) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *ARCCache[K]) Get(key K) (value any, ok bool) {
+func (c *ARCCache[K, V]) Get(key K) (value V, ok bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -78,11 +78,11 @@ func (c *ARCCache[K]) Get(key K) (value any, ok bool) {
 	}
 
 	// No hit
-	return nil, false
+	return value, false
 }
 
 // Add adds a value to the cache.
-func (c *ARCCache[K]) Add(key K, value any) {
+func (c *ARCCache[K, V]) Add(key K, value V) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -177,30 +177,32 @@ func (c *ARCCache[K]) Add(key K, value any) {
 
 // replace is used to adaptively evict from either T1 or T2
 // based on the current learned value of P
-func (c *ARCCache[K]) replace(b2ContainsKey bool) {
+func (c *ARCCache[K, V]) replace(b2ContainsKey bool) {
 	t1Len := c.t1.Len()
 	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
 		k, _, ok := c.t1.RemoveOldest()
 		if ok {
-			c.b1.Add(k, nil)
+			var v V
+			c.b1.Add(k, v)
 		}
 	} else {
 		k, _, ok := c.t2.RemoveOldest()
 		if ok {
-			c.b2.Add(k, nil)
+			var v V
+			c.b2.Add(k, v)
 		}
 	}
 }
 
 // Len returns the number of cached entries
-func (c *ARCCache[K]) Len() int {
+func (c *ARCCache[K, V]) Len() int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.t1.Len() + c.t2.Len()
 }
 
 // Keys returns all the cached keys
-func (c *ARCCache[K]) Keys() []K {
+func (c *ARCCache[K, V]) Keys() []K {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	k1 := c.t1.Keys()
@@ -209,7 +211,7 @@ func (c *ARCCache[K]) Keys() []K {
 }
 
 // Remove is used to purge a key from the cache
-func (c *ARCCache[K]) Remove(key K) {
+func (c *ARCCache[K, V]) Remove(key K) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.t1.Remove(key) {
@@ -227,7 +229,7 @@ func (c *ARCCache[K]) Remove(key K) {
 }
 
 // Purge is used to clear the cache
-func (c *ARCCache[K]) Purge() {
+func (c *ARCCache[K, V]) Purge() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.t1.Purge()
@@ -238,7 +240,7 @@ func (c *ARCCache[K]) Purge() {
 
 // Contains is used to check if the cache contains a key
 // without updating recency or frequency.
-func (c *ARCCache[K]) Contains(key K) bool {
+func (c *ARCCache[K, V]) Contains(key K) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.t1.Contains(key) || c.t2.Contains(key)
@@ -246,7 +248,7 @@ func (c *ARCCache[K]) Contains(key K) bool {
 
 // Peek is used to inspect the cache value of a key
 // without updating recency or frequency.
-func (c *ARCCache[K]) Peek(key K) (value any, ok bool) {
+func (c *ARCCache[K, V]) Peek(key K) (value V, ok bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if val, ok := c.t1.Peek(key); ok {

--- a/arc_test.go
+++ b/arc_test.go
@@ -11,7 +11,7 @@ func init() {
 }
 
 func BenchmarkARC_Rand(b *testing.B) {
-	l, err := NewARC(8192)
+	l, err := NewARC[int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -40,7 +40,7 @@ func BenchmarkARC_Rand(b *testing.B) {
 }
 
 func BenchmarkARC_Freq(b *testing.B) {
-	l, err := NewARC(8192)
+	l, err := NewARC[int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -73,7 +73,7 @@ func BenchmarkARC_Freq(b *testing.B) {
 
 func TestARC_RandomOps(t *testing.T) {
 	size := 128
-	l, err := NewARC(128)
+	l, err := NewARC[int64](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestARC_RandomOps(t *testing.T) {
 }
 
 func TestARC_Get_RecentToFrequent(t *testing.T) {
-	l, err := NewARC(128)
+	l, err := NewARC[int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestARC_Get_RecentToFrequent(t *testing.T) {
 }
 
 func TestARC_Add_RecentToFrequent(t *testing.T) {
-	l, err := NewARC(128)
+	l, err := NewARC[int64](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestARC_Add_RecentToFrequent(t *testing.T) {
 }
 
 func TestARC_Adaptive(t *testing.T) {
-	l, err := NewARC(4)
+	l, err := NewARC[int](4)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestARC_Adaptive(t *testing.T) {
 }
 
 func TestARC(t *testing.T) {
-	l, err := NewARC(128)
+	l, err := NewARC[int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestARC(t *testing.T) {
 
 // Test that Contains doesn't update recent-ness
 func TestARC_Contains(t *testing.T) {
-	l, err := NewARC(2)
+	l, err := NewARC[int64](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestARC_Contains(t *testing.T) {
 
 // Test that Peek doesn't update recent-ness
 func TestARC_Peek(t *testing.T) {
-	l, err := NewARC(2)
+	l, err := NewARC[int64](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/arc_test.go
+++ b/arc_test.go
@@ -11,7 +11,7 @@ func init() {
 }
 
 func BenchmarkARC_Rand(b *testing.B) {
-	l, err := NewARC[int64](8192)
+	l, err := NewARC[int64, int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -40,7 +40,7 @@ func BenchmarkARC_Rand(b *testing.B) {
 }
 
 func BenchmarkARC_Freq(b *testing.B) {
-	l, err := NewARC[int64](8192)
+	l, err := NewARC[int64, int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -73,7 +73,7 @@ func BenchmarkARC_Freq(b *testing.B) {
 
 func TestARC_RandomOps(t *testing.T) {
 	size := 128
-	l, err := NewARC[int64](128)
+	l, err := NewARC[int64, int64](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestARC_RandomOps(t *testing.T) {
 }
 
 func TestARC_Get_RecentToFrequent(t *testing.T) {
-	l, err := NewARC[int](128)
+	l, err := NewARC[int, int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestARC_Get_RecentToFrequent(t *testing.T) {
 }
 
 func TestARC_Add_RecentToFrequent(t *testing.T) {
-	l, err := NewARC[int64](128)
+	l, err := NewARC[int64, int64](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestARC_Add_RecentToFrequent(t *testing.T) {
 }
 
 func TestARC_Adaptive(t *testing.T) {
-	l, err := NewARC[int](4)
+	l, err := NewARC[int, int](4)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestARC_Adaptive(t *testing.T) {
 }
 
 func TestARC(t *testing.T) {
-	l, err := NewARC[int](128)
+	l, err := NewARC[int, int](128)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestARC(t *testing.T) {
 
 // Test that Contains doesn't update recent-ness
 func TestARC_Contains(t *testing.T) {
-	l, err := NewARC[int64](2)
+	l, err := NewARC[int64, int64](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestARC_Contains(t *testing.T) {
 
 // Test that Peek doesn't update recent-ness
 func TestARC_Peek(t *testing.T) {
-	l, err := NewARC[int64](2)
+	l, err := NewARC[int64, int64](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hashicorp/golang-lru
 
-go 1.12
+go 1.18

--- a/lru.go
+++ b/lru.go
@@ -12,23 +12,24 @@ const (
 )
 
 // Cache is a thread-safe fixed size LRU cache.
-type Cache struct {
-	lru                      *simplelru.LRU
-	evictedKeys, evictedVals []any
-	onEvictedCB              func(k, v any)
-	lock                     sync.RWMutex
+type Cache[K comparable] struct {
+	lru         *simplelru.LRU[K]
+	evictedKeys []K
+	evictedVals []any
+	onEvictedCB func(k K, v any)
+	lock        sync.RWMutex
 }
 
 // New creates an LRU of the given size.
-func New(size int) (*Cache, error) {
-	return NewWithEvict(size, nil)
+func New[K comparable](size int) (*Cache[K], error) {
+	return NewWithEvict[K](size, nil)
 }
 
 // NewWithEvict constructs a fixed size cache with the given eviction
 // callback.
-func NewWithEvict(size int, onEvicted func(key, value any)) (c *Cache, err error) {
+func NewWithEvict[K comparable](size int, onEvicted func(key K, value any)) (c *Cache[K], err error) {
 	// create a cache with default settings
-	c = &Cache{
+	c = &Cache[K]{
 		onEvictedCB: onEvicted,
 	}
 	if onEvicted != nil {
@@ -39,21 +40,22 @@ func NewWithEvict(size int, onEvicted func(key, value any)) (c *Cache, err error
 	return
 }
 
-func (c *Cache) initEvictBuffers() {
-	c.evictedKeys = make([]any, 0, DefaultEvictedBufferSize)
+func (c *Cache[K]) initEvictBuffers() {
+	c.evictedKeys = make([]K, 0, DefaultEvictedBufferSize)
 	c.evictedVals = make([]any, 0, DefaultEvictedBufferSize)
 }
 
 // onEvicted save evicted key/val and sent in externally registered callback
-// outside of critical section
-func (c *Cache) onEvicted(k, v any) {
+// outside critical section
+func (c *Cache[K]) onEvicted(k K, v any) {
 	c.evictedKeys = append(c.evictedKeys, k)
 	c.evictedVals = append(c.evictedVals, v)
 }
 
 // Purge is used to completely clear the cache.
-func (c *Cache) Purge() {
-	var ks, vs []any
+func (c *Cache[K]) Purge() {
+	var ks []K
+	var vs []any
 	c.lock.Lock()
 	c.lru.Purge()
 	if c.onEvictedCB != nil && len(c.evictedKeys) > 0 {
@@ -61,7 +63,7 @@ func (c *Cache) Purge() {
 		c.initEvictBuffers()
 	}
 	c.lock.Unlock()
-	// invoke callback outside of critical section
+	// invoke callback outside critical section
 	if c.onEvictedCB != nil {
 		for i := 0; i < len(ks); i++ {
 			c.onEvictedCB(ks[i], vs[i])
@@ -70,8 +72,9 @@ func (c *Cache) Purge() {
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
-func (c *Cache) Add(key, value any) (evicted bool) {
-	var k, v any
+func (c *Cache[K]) Add(key K, value any) (evicted bool) {
+	var k K
+	var v any
 	c.lock.Lock()
 	evicted = c.lru.Add(key, value)
 	if c.onEvictedCB != nil && evicted {
@@ -86,7 +89,7 @@ func (c *Cache) Add(key, value any) (evicted bool) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *Cache) Get(key any) (value any, ok bool) {
+func (c *Cache[K]) Get(key K) (value any, ok bool) {
 	c.lock.Lock()
 	value, ok = c.lru.Get(key)
 	c.lock.Unlock()
@@ -95,7 +98,7 @@ func (c *Cache) Get(key any) (value any, ok bool) {
 
 // Contains checks if a key is in the cache, without updating the
 // recent-ness or deleting it for being stale.
-func (c *Cache) Contains(key any) bool {
+func (c *Cache[K]) Contains(key K) bool {
 	c.lock.RLock()
 	containKey := c.lru.Contains(key)
 	c.lock.RUnlock()
@@ -104,7 +107,7 @@ func (c *Cache) Contains(key any) bool {
 
 // Peek returns the key value (or undefined if not found) without updating
 // the "recently used"-ness of the key.
-func (c *Cache) Peek(key any) (value any, ok bool) {
+func (c *Cache[K]) Peek(key K) (value any, ok bool) {
 	c.lock.RLock()
 	value, ok = c.lru.Peek(key)
 	c.lock.RUnlock()
@@ -114,8 +117,9 @@ func (c *Cache) Peek(key any) (value any, ok bool) {
 // ContainsOrAdd checks if a key is in the cache without updating the
 // recent-ness or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
-func (c *Cache) ContainsOrAdd(key, value any) (ok, evicted bool) {
-	var k, v any
+func (c *Cache[K]) ContainsOrAdd(key K, value any) (ok, evicted bool) {
+	var k K
+	var v any
 	c.lock.Lock()
 	if c.lru.Contains(key) {
 		c.lock.Unlock()
@@ -136,8 +140,9 @@ func (c *Cache) ContainsOrAdd(key, value any) (ok, evicted bool) {
 // PeekOrAdd checks if a key is in the cache without updating the
 // recent-ness or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
-func (c *Cache) PeekOrAdd(key, value any) (previous any, ok, evicted bool) {
-	var k, v any
+func (c *Cache[K]) PeekOrAdd(key K, value any) (previous any, ok, evicted bool) {
+	var k K
+	var v any
 	c.lock.Lock()
 	previous, ok = c.lru.Peek(key)
 	if ok {
@@ -157,8 +162,9 @@ func (c *Cache) PeekOrAdd(key, value any) (previous any, ok, evicted bool) {
 }
 
 // Remove removes the provided key from the cache.
-func (c *Cache) Remove(key any) (present bool) {
-	var k, v any
+func (c *Cache[K]) Remove(key K) (present bool) {
+	var k K
+	var v any
 	c.lock.Lock()
 	present = c.lru.Remove(key)
 	if c.onEvictedCB != nil && present {
@@ -173,8 +179,9 @@ func (c *Cache) Remove(key any) (present bool) {
 }
 
 // Resize changes the cache size.
-func (c *Cache) Resize(size int) (evicted int) {
-	var ks, vs []any
+func (c *Cache[K]) Resize(size int) (evicted int) {
+	var ks []K
+	var vs []any
 	c.lock.Lock()
 	evicted = c.lru.Resize(size)
 	if c.onEvictedCB != nil && evicted > 0 {
@@ -191,8 +198,9 @@ func (c *Cache) Resize(size int) (evicted int) {
 }
 
 // RemoveOldest removes the oldest item from the cache.
-func (c *Cache) RemoveOldest() (key, value any, ok bool) {
-	var k, v any
+func (c *Cache[K]) RemoveOldest() (key K, value any, ok bool) {
+	var k K
+	var v any
 	c.lock.Lock()
 	key, value, ok = c.lru.RemoveOldest()
 	if c.onEvictedCB != nil && ok {
@@ -207,7 +215,7 @@ func (c *Cache) RemoveOldest() (key, value any, ok bool) {
 }
 
 // GetOldest returns the oldest entry
-func (c *Cache) GetOldest() (key, value any, ok bool) {
+func (c *Cache[K]) GetOldest() (key K, value any, ok bool) {
 	c.lock.RLock()
 	key, value, ok = c.lru.GetOldest()
 	c.lock.RUnlock()
@@ -215,7 +223,7 @@ func (c *Cache) GetOldest() (key, value any, ok bool) {
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
-func (c *Cache) Keys() []any {
+func (c *Cache[K]) Keys() []K {
 	c.lock.RLock()
 	keys := c.lru.Keys()
 	c.lock.RUnlock()
@@ -223,7 +231,7 @@ func (c *Cache) Keys() []any {
 }
 
 // Len returns the number of items in the cache.
-func (c *Cache) Len() int {
+func (c *Cache[K]) Len() int {
 	c.lock.RLock()
 	length := c.lru.Len()
 	c.lock.RUnlock()

--- a/lru.go
+++ b/lru.go
@@ -12,24 +12,24 @@ const (
 )
 
 // Cache is a thread-safe fixed size LRU cache.
-type Cache[K comparable] struct {
-	lru         *simplelru.LRU[K]
+type Cache[K comparable, V any] struct {
+	lru         *simplelru.LRU[K, V]
 	evictedKeys []K
-	evictedVals []any
-	onEvictedCB func(k K, v any)
+	evictedVals []V
+	onEvictedCB func(k K, v V)
 	lock        sync.RWMutex
 }
 
 // New creates an LRU of the given size.
-func New[K comparable](size int) (*Cache[K], error) {
-	return NewWithEvict[K](size, nil)
+func New[K comparable, V any](size int) (*Cache[K, V], error) {
+	return NewWithEvict[K, V](size, nil)
 }
 
 // NewWithEvict constructs a fixed size cache with the given eviction
 // callback.
-func NewWithEvict[K comparable](size int, onEvicted func(key K, value any)) (c *Cache[K], err error) {
+func NewWithEvict[K comparable, V any](size int, onEvicted func(key K, value V)) (c *Cache[K, V], err error) {
 	// create a cache with default settings
-	c = &Cache[K]{
+	c = &Cache[K, V]{
 		onEvictedCB: onEvicted,
 	}
 	if onEvicted != nil {
@@ -40,22 +40,22 @@ func NewWithEvict[K comparable](size int, onEvicted func(key K, value any)) (c *
 	return
 }
 
-func (c *Cache[K]) initEvictBuffers() {
+func (c *Cache[K, V]) initEvictBuffers() {
 	c.evictedKeys = make([]K, 0, DefaultEvictedBufferSize)
-	c.evictedVals = make([]any, 0, DefaultEvictedBufferSize)
+	c.evictedVals = make([]V, 0, DefaultEvictedBufferSize)
 }
 
 // onEvicted save evicted key/val and sent in externally registered callback
 // outside critical section
-func (c *Cache[K]) onEvicted(k K, v any) {
+func (c *Cache[K, V]) onEvicted(k K, v V) {
 	c.evictedKeys = append(c.evictedKeys, k)
 	c.evictedVals = append(c.evictedVals, v)
 }
 
 // Purge is used to completely clear the cache.
-func (c *Cache[K]) Purge() {
+func (c *Cache[K, V]) Purge() {
 	var ks []K
-	var vs []any
+	var vs []V
 	c.lock.Lock()
 	c.lru.Purge()
 	if c.onEvictedCB != nil && len(c.evictedKeys) > 0 {
@@ -72,9 +72,9 @@ func (c *Cache[K]) Purge() {
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
-func (c *Cache[K]) Add(key K, value any) (evicted bool) {
+func (c *Cache[K, V]) Add(key K, value V) (evicted bool) {
 	var k K
-	var v any
+	var v V
 	c.lock.Lock()
 	evicted = c.lru.Add(key, value)
 	if c.onEvictedCB != nil && evicted {
@@ -89,7 +89,7 @@ func (c *Cache[K]) Add(key K, value any) (evicted bool) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *Cache[K]) Get(key K) (value any, ok bool) {
+func (c *Cache[K, V]) Get(key K) (value V, ok bool) {
 	c.lock.Lock()
 	value, ok = c.lru.Get(key)
 	c.lock.Unlock()
@@ -98,7 +98,7 @@ func (c *Cache[K]) Get(key K) (value any, ok bool) {
 
 // Contains checks if a key is in the cache, without updating the
 // recent-ness or deleting it for being stale.
-func (c *Cache[K]) Contains(key K) bool {
+func (c *Cache[K, V]) Contains(key K) bool {
 	c.lock.RLock()
 	containKey := c.lru.Contains(key)
 	c.lock.RUnlock()
@@ -107,7 +107,7 @@ func (c *Cache[K]) Contains(key K) bool {
 
 // Peek returns the key value (or undefined if not found) without updating
 // the "recently used"-ness of the key.
-func (c *Cache[K]) Peek(key K) (value any, ok bool) {
+func (c *Cache[K, V]) Peek(key K) (value V, ok bool) {
 	c.lock.RLock()
 	value, ok = c.lru.Peek(key)
 	c.lock.RUnlock()
@@ -117,9 +117,9 @@ func (c *Cache[K]) Peek(key K) (value any, ok bool) {
 // ContainsOrAdd checks if a key is in the cache without updating the
 // recent-ness or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
-func (c *Cache[K]) ContainsOrAdd(key K, value any) (ok, evicted bool) {
+func (c *Cache[K, V]) ContainsOrAdd(key K, value V) (ok, evicted bool) {
 	var k K
-	var v any
+	var v V
 	c.lock.Lock()
 	if c.lru.Contains(key) {
 		c.lock.Unlock()
@@ -140,9 +140,9 @@ func (c *Cache[K]) ContainsOrAdd(key K, value any) (ok, evicted bool) {
 // PeekOrAdd checks if a key is in the cache without updating the
 // recent-ness or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
-func (c *Cache[K]) PeekOrAdd(key K, value any) (previous any, ok, evicted bool) {
+func (c *Cache[K, V]) PeekOrAdd(key K, value V) (previous any, ok, evicted bool) {
 	var k K
-	var v any
+	var v V
 	c.lock.Lock()
 	previous, ok = c.lru.Peek(key)
 	if ok {
@@ -162,9 +162,9 @@ func (c *Cache[K]) PeekOrAdd(key K, value any) (previous any, ok, evicted bool) 
 }
 
 // Remove removes the provided key from the cache.
-func (c *Cache[K]) Remove(key K) (present bool) {
+func (c *Cache[K, V]) Remove(key K) (present bool) {
 	var k K
-	var v any
+	var v V
 	c.lock.Lock()
 	present = c.lru.Remove(key)
 	if c.onEvictedCB != nil && present {
@@ -179,9 +179,9 @@ func (c *Cache[K]) Remove(key K) (present bool) {
 }
 
 // Resize changes the cache size.
-func (c *Cache[K]) Resize(size int) (evicted int) {
+func (c *Cache[K, V]) Resize(size int) (evicted int) {
 	var ks []K
-	var vs []any
+	var vs []V
 	c.lock.Lock()
 	evicted = c.lru.Resize(size)
 	if c.onEvictedCB != nil && evicted > 0 {
@@ -198,9 +198,9 @@ func (c *Cache[K]) Resize(size int) (evicted int) {
 }
 
 // RemoveOldest removes the oldest item from the cache.
-func (c *Cache[K]) RemoveOldest() (key K, value any, ok bool) {
+func (c *Cache[K, V]) RemoveOldest() (key K, value V, ok bool) {
 	var k K
-	var v any
+	var v V
 	c.lock.Lock()
 	key, value, ok = c.lru.RemoveOldest()
 	if c.onEvictedCB != nil && ok {
@@ -215,7 +215,7 @@ func (c *Cache[K]) RemoveOldest() (key K, value any, ok bool) {
 }
 
 // GetOldest returns the oldest entry
-func (c *Cache[K]) GetOldest() (key K, value any, ok bool) {
+func (c *Cache[K, V]) GetOldest() (key K, value V, ok bool) {
 	c.lock.RLock()
 	key, value, ok = c.lru.GetOldest()
 	c.lock.RUnlock()
@@ -223,7 +223,7 @@ func (c *Cache[K]) GetOldest() (key K, value any, ok bool) {
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
-func (c *Cache[K]) Keys() []K {
+func (c *Cache[K, V]) Keys() []K {
 	c.lock.RLock()
 	keys := c.lru.Keys()
 	c.lock.RUnlock()
@@ -231,7 +231,7 @@ func (c *Cache[K]) Keys() []K {
 }
 
 // Len returns the number of items in the cache.
-func (c *Cache[K]) Len() int {
+func (c *Cache[K, V]) Len() int {
 	c.lock.RLock()
 	length := c.lru.Len()
 	c.lock.RUnlock()

--- a/lru_test.go
+++ b/lru_test.go
@@ -68,7 +68,7 @@ func BenchmarkLRU_Freq(b *testing.B) {
 
 func TestLRU(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
+	onEvicted := func(k any, v any) {
 		if k != v {
 			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
 		}
@@ -135,7 +135,7 @@ func TestLRU(t *testing.T) {
 // test that Add returns true/false if an eviction occurred
 func TestLRUAdd(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
+	onEvicted := func(k any, v any) {
 		evictCounter++
 	}
 
@@ -256,7 +256,7 @@ func TestLRUPeek(t *testing.T) {
 // test that Resize can upsize and downsize
 func TestLRUResize(t *testing.T) {
 	onEvictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
+	onEvicted := func(k any, v any) {
 		onEvictCounter++
 	}
 	l, err := NewWithEvict(2, onEvicted)

--- a/lru_test.go
+++ b/lru_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func BenchmarkLRU_Rand(b *testing.B) {
-	l, err := New[int64](8192)
+	l, err := New[int64, int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -35,7 +35,7 @@ func BenchmarkLRU_Rand(b *testing.B) {
 }
 
 func BenchmarkLRU_Freq(b *testing.B) {
-	l, err := New[int64](8192)
+	l, err := New[int64, int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -68,13 +68,13 @@ func BenchmarkLRU_Freq(b *testing.B) {
 
 func TestLRU(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k int, v any) {
+	onEvicted := func(k int, v int) {
 		if k != v {
 			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
 		}
 		evictCounter++
 	}
-	l, err := NewWithEvict[int](128, onEvicted)
+	l, err := NewWithEvict[int, int](128, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -135,11 +135,11 @@ func TestLRU(t *testing.T) {
 // test that Add returns true/false if an eviction occurred
 func TestLRUAdd(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k int, v any) {
+	onEvicted := func(k int, v int) {
 		evictCounter++
 	}
 
-	l, err := NewWithEvict[int](1, onEvicted)
+	l, err := NewWithEvict[int, int](1, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestLRUAdd(t *testing.T) {
 
 // test that Contains doesn't update recent-ness
 func TestLRUContains(t *testing.T) {
-	l, err := New[int](2)
+	l, err := New[int, int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestLRUContains(t *testing.T) {
 
 // test that ContainsOrAdd doesn't update recent-ness
 func TestLRUContainsOrAdd(t *testing.T) {
-	l, err := New[int](2)
+	l, err := New[int, int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestLRUContainsOrAdd(t *testing.T) {
 
 // test that PeekOrAdd doesn't update recent-ness
 func TestLRUPeekOrAdd(t *testing.T) {
-	l, err := New[int](2)
+	l, err := New[int, int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestLRUPeekOrAdd(t *testing.T) {
 
 // test that Peek doesn't update recent-ness
 func TestLRUPeek(t *testing.T) {
-	l, err := New[int](2)
+	l, err := New[int, int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -256,10 +256,10 @@ func TestLRUPeek(t *testing.T) {
 // test that Resize can upsize and downsize
 func TestLRUResize(t *testing.T) {
 	onEvictCounter := 0
-	onEvicted := func(k int, v any) {
+	onEvicted := func(k int, v int) {
 		onEvictCounter++
 	}
-	l, err := NewWithEvict[int](2, onEvicted)
+	l, err := NewWithEvict[int, int](2, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/lru_test.go
+++ b/lru_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func BenchmarkLRU_Rand(b *testing.B) {
-	l, err := New(8192)
+	l, err := New[int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -35,7 +35,7 @@ func BenchmarkLRU_Rand(b *testing.B) {
 }
 
 func BenchmarkLRU_Freq(b *testing.B) {
-	l, err := New(8192)
+	l, err := New[int64](8192)
 	if err != nil {
 		b.Fatalf("err: %v", err)
 	}
@@ -68,13 +68,13 @@ func BenchmarkLRU_Freq(b *testing.B) {
 
 func TestLRU(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k any, v any) {
+	onEvicted := func(k int, v any) {
 		if k != v {
 			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
 		}
 		evictCounter++
 	}
-	l, err := NewWithEvict(128, onEvicted)
+	l, err := NewWithEvict[int](128, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -135,11 +135,11 @@ func TestLRU(t *testing.T) {
 // test that Add returns true/false if an eviction occurred
 func TestLRUAdd(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k any, v any) {
+	onEvicted := func(k int, v any) {
 		evictCounter++
 	}
 
-	l, err := NewWithEvict(1, onEvicted)
+	l, err := NewWithEvict[int](1, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestLRUAdd(t *testing.T) {
 
 // test that Contains doesn't update recent-ness
 func TestLRUContains(t *testing.T) {
-	l, err := New(2)
+	l, err := New[int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestLRUContains(t *testing.T) {
 
 // test that ContainsOrAdd doesn't update recent-ness
 func TestLRUContainsOrAdd(t *testing.T) {
-	l, err := New(2)
+	l, err := New[int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestLRUContainsOrAdd(t *testing.T) {
 
 // test that PeekOrAdd doesn't update recent-ness
 func TestLRUPeekOrAdd(t *testing.T) {
-	l, err := New(2)
+	l, err := New[int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestLRUPeekOrAdd(t *testing.T) {
 
 // test that Peek doesn't update recent-ness
 func TestLRUPeek(t *testing.T) {
-	l, err := New(2)
+	l, err := New[int](2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -256,10 +256,10 @@ func TestLRUPeek(t *testing.T) {
 // test that Resize can upsize and downsize
 func TestLRUResize(t *testing.T) {
 	onEvictCounter := 0
-	onEvicted := func(k any, v any) {
+	onEvicted := func(k int, v any) {
 		onEvictCounter++
 	}
-	l, err := NewWithEvict(2, onEvicted)
+	l, err := NewWithEvict[int](2, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -6,28 +6,28 @@ import (
 )
 
 // EvictCallback is used to get a callback when a cache entry is evicted
-type EvictCallback[K comparable] func(key K, value any)
+type EvictCallback[K comparable, V any] func(key K, value V)
 
 // LRU implements a non-thread safe fixed size LRU cache
-type LRU[K comparable] struct {
+type LRU[K comparable, V any] struct {
 	size      int
 	evictList *list.List
 	items     map[K]*list.Element
-	onEvict   EvictCallback[K]
+	onEvict   EvictCallback[K, V]
 }
 
 // entry is used to hold a value in the evictList
-type entry[K comparable] struct {
+type entry[K comparable, V any] struct {
 	key   K
-	value any
+	value V
 }
 
 // NewLRU constructs an LRU of the given size
-func NewLRU[K comparable](size int, onEvict EvictCallback[K]) (*LRU[K], error) {
+func NewLRU[K comparable, V any](size int, onEvict EvictCallback[K, V]) (*LRU[K, V], error) {
 	if size <= 0 {
 		return nil, errors.New("must provide a positive size")
 	}
-	c := &LRU[K]{
+	c := &LRU[K, V]{
 		size:      size,
 		evictList: list.New(),
 		items:     make(map[K]*list.Element),
@@ -37,10 +37,10 @@ func NewLRU[K comparable](size int, onEvict EvictCallback[K]) (*LRU[K], error) {
 }
 
 // Purge is used to completely clear the cache.
-func (c *LRU[K]) Purge() {
+func (c *LRU[K, V]) Purge() {
 	for k, v := range c.items {
 		if c.onEvict != nil {
-			c.onEvict(k, v.Value.(*entry[K]).value)
+			c.onEvict(k, v.Value.(*entry[K, V]).value)
 		}
 		delete(c.items, k)
 	}
@@ -48,16 +48,16 @@ func (c *LRU[K]) Purge() {
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occurred.
-func (c *LRU[K]) Add(key K, value any) (evicted bool) {
+func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
-		ent.Value.(*entry[K]).value = value
+		ent.Value.(*entry[K, V]).value = value
 		return false
 	}
 
 	// Add new item
-	ent := &entry[K]{key, value}
+	ent := &entry[K, V]{key, value}
 	entry := c.evictList.PushFront(ent)
 	c.items[key] = entry
 
@@ -70,37 +70,37 @@ func (c *LRU[K]) Add(key K, value any) (evicted bool) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *LRU[K]) Get(key K) (value any, ok bool) {
+func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
-		if ent.Value.(*entry[K]) == nil {
-			return nil, false
+		if ent.Value.(*entry[K, V]) == nil {
+			return value, false
 		}
-		return ent.Value.(*entry[K]).value, true
+		return ent.Value.(*entry[K, V]).value, true
 	}
 	return
 }
 
 // Contains checks if a key is in the cache, without updating the recent-ness
 // or deleting it for being stale.
-func (c *LRU[K]) Contains(key K) (ok bool) {
+func (c *LRU[K, V]) Contains(key K) (ok bool) {
 	_, ok = c.items[key]
 	return ok
 }
 
 // Peek returns the key value (or undefined if not found) without updating
 // the "recently used"-ness of the key.
-func (c *LRU[K]) Peek(key K) (value any, ok bool) {
+func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
 	var ent *list.Element
 	if ent, ok = c.items[key]; ok {
-		return ent.Value.(*entry[K]).value, true
+		return ent.Value.(*entry[K, V]).value, true
 	}
-	return nil, ok
+	return value, ok
 }
 
 // Remove removes the provided key from the cache, returning if the
 // key was contained.
-func (c *LRU[K]) Remove(key K) (present bool) {
+func (c *LRU[K, V]) Remove(key K) (present bool) {
 	if ent, ok := c.items[key]; ok {
 		c.removeElement(ent)
 		return true
@@ -109,46 +109,46 @@ func (c *LRU[K]) Remove(key K) (present bool) {
 }
 
 // RemoveOldest removes the oldest item from the cache.
-func (c *LRU[K]) RemoveOldest() (key K, value any, ok bool) {
+func (c *LRU[K, V]) RemoveOldest() (key K, value V, ok bool) {
 	ent := c.evictList.Back()
 	if ent != nil {
 		c.removeElement(ent)
-		kv := ent.Value.(*entry[K])
+		kv := ent.Value.(*entry[K, V])
 		return kv.key, kv.value, true
 	}
 	var k K
-	return k, nil, false
+	return k, value, false
 }
 
 // GetOldest returns the oldest entry
-func (c *LRU[K]) GetOldest() (key K, value any, ok bool) {
+func (c *LRU[K, V]) GetOldest() (key K, value V, ok bool) {
 	ent := c.evictList.Back()
 	if ent != nil {
-		kv := ent.Value.(*entry[K])
+		kv := ent.Value.(*entry[K, V])
 		return kv.key, kv.value, true
 	}
 	var k K
-	return k, nil, false
+	return k, value, false
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
-func (c *LRU[K]) Keys() []K {
+func (c *LRU[K, V]) Keys() []K {
 	keys := make([]K, len(c.items))
 	i := 0
 	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
-		keys[i] = ent.Value.(*entry[K]).key
+		keys[i] = ent.Value.(*entry[K, V]).key
 		i++
 	}
 	return keys
 }
 
 // Len returns the number of items in the cache.
-func (c *LRU[K]) Len() int {
+func (c *LRU[K, V]) Len() int {
 	return c.evictList.Len()
 }
 
 // Resize changes the cache size.
-func (c *LRU[K]) Resize(size int) (evicted int) {
+func (c *LRU[K, V]) Resize(size int) (evicted int) {
 	diff := c.Len() - size
 	if diff < 0 {
 		diff = 0
@@ -161,7 +161,7 @@ func (c *LRU[K]) Resize(size int) (evicted int) {
 }
 
 // removeOldest removes the oldest item from the cache.
-func (c *LRU[K]) removeOldest() {
+func (c *LRU[K, V]) removeOldest() {
 	ent := c.evictList.Back()
 	if ent != nil {
 		c.removeElement(ent)
@@ -169,9 +169,9 @@ func (c *LRU[K]) removeOldest() {
 }
 
 // removeElement is used to remove a given list element from the cache
-func (c *LRU[K]) removeElement(e *list.Element) {
+func (c *LRU[K, V]) removeElement(e *list.Element) {
 	c.evictList.Remove(e)
-	kv := e.Value.(*entry[K])
+	kv := e.Value.(*entry[K, V])
 	delete(c.items, kv.key)
 	if c.onEvict != nil {
 		c.onEvict(kv.key, kv.value)

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -6,41 +6,41 @@ import (
 )
 
 // EvictCallback is used to get a callback when a cache entry is evicted
-type EvictCallback func(key any, value any)
+type EvictCallback[K comparable] func(key K, value any)
 
 // LRU implements a non-thread safe fixed size LRU cache
-type LRU struct {
+type LRU[K comparable] struct {
 	size      int
 	evictList *list.List
-	items     map[any]*list.Element
-	onEvict   EvictCallback
+	items     map[K]*list.Element
+	onEvict   EvictCallback[K]
 }
 
 // entry is used to hold a value in the evictList
-type entry struct {
-	key   any
+type entry[K comparable] struct {
+	key   K
 	value any
 }
 
 // NewLRU constructs an LRU of the given size
-func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
+func NewLRU[K comparable](size int, onEvict EvictCallback[K]) (*LRU[K], error) {
 	if size <= 0 {
 		return nil, errors.New("must provide a positive size")
 	}
-	c := &LRU{
+	c := &LRU[K]{
 		size:      size,
 		evictList: list.New(),
-		items:     make(map[any]*list.Element),
+		items:     make(map[K]*list.Element),
 		onEvict:   onEvict,
 	}
 	return c, nil
 }
 
 // Purge is used to completely clear the cache.
-func (c *LRU) Purge() {
+func (c *LRU[K]) Purge() {
 	for k, v := range c.items {
 		if c.onEvict != nil {
-			c.onEvict(k, v.Value.(*entry).value)
+			c.onEvict(k, v.Value.(*entry[K]).value)
 		}
 		delete(c.items, k)
 	}
@@ -48,16 +48,16 @@ func (c *LRU) Purge() {
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occurred.
-func (c *LRU) Add(key, value any) (evicted bool) {
+func (c *LRU[K]) Add(key K, value any) (evicted bool) {
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
-		ent.Value.(*entry).value = value
+		ent.Value.(*entry[K]).value = value
 		return false
 	}
 
 	// Add new item
-	ent := &entry{key, value}
+	ent := &entry[K]{key, value}
 	entry := c.evictList.PushFront(ent)
 	c.items[key] = entry
 
@@ -70,37 +70,37 @@ func (c *LRU) Add(key, value any) (evicted bool) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *LRU) Get(key any) (value any, ok bool) {
+func (c *LRU[K]) Get(key K) (value any, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
-		if ent.Value.(*entry) == nil {
+		if ent.Value.(*entry[K]) == nil {
 			return nil, false
 		}
-		return ent.Value.(*entry).value, true
+		return ent.Value.(*entry[K]).value, true
 	}
 	return
 }
 
 // Contains checks if a key is in the cache, without updating the recent-ness
 // or deleting it for being stale.
-func (c *LRU) Contains(key any) (ok bool) {
+func (c *LRU[K]) Contains(key K) (ok bool) {
 	_, ok = c.items[key]
 	return ok
 }
 
 // Peek returns the key value (or undefined if not found) without updating
 // the "recently used"-ness of the key.
-func (c *LRU) Peek(key any) (value any, ok bool) {
+func (c *LRU[K]) Peek(key K) (value any, ok bool) {
 	var ent *list.Element
 	if ent, ok = c.items[key]; ok {
-		return ent.Value.(*entry).value, true
+		return ent.Value.(*entry[K]).value, true
 	}
 	return nil, ok
 }
 
 // Remove removes the provided key from the cache, returning if the
 // key was contained.
-func (c *LRU) Remove(key any) (present bool) {
+func (c *LRU[K]) Remove(key K) (present bool) {
 	if ent, ok := c.items[key]; ok {
 		c.removeElement(ent)
 		return true
@@ -109,44 +109,46 @@ func (c *LRU) Remove(key any) (present bool) {
 }
 
 // RemoveOldest removes the oldest item from the cache.
-func (c *LRU) RemoveOldest() (key, value any, ok bool) {
+func (c *LRU[K]) RemoveOldest() (key K, value any, ok bool) {
 	ent := c.evictList.Back()
 	if ent != nil {
 		c.removeElement(ent)
-		kv := ent.Value.(*entry)
+		kv := ent.Value.(*entry[K])
 		return kv.key, kv.value, true
 	}
-	return nil, nil, false
+	var k K
+	return k, nil, false
 }
 
 // GetOldest returns the oldest entry
-func (c *LRU) GetOldest() (key, value any, ok bool) {
+func (c *LRU[K]) GetOldest() (key K, value any, ok bool) {
 	ent := c.evictList.Back()
 	if ent != nil {
-		kv := ent.Value.(*entry)
+		kv := ent.Value.(*entry[K])
 		return kv.key, kv.value, true
 	}
-	return nil, nil, false
+	var k K
+	return k, nil, false
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
-func (c *LRU) Keys() []any {
-	keys := make([]any, len(c.items))
+func (c *LRU[K]) Keys() []K {
+	keys := make([]K, len(c.items))
 	i := 0
 	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
-		keys[i] = ent.Value.(*entry).key
+		keys[i] = ent.Value.(*entry[K]).key
 		i++
 	}
 	return keys
 }
 
 // Len returns the number of items in the cache.
-func (c *LRU) Len() int {
+func (c *LRU[K]) Len() int {
 	return c.evictList.Len()
 }
 
 // Resize changes the cache size.
-func (c *LRU) Resize(size int) (evicted int) {
+func (c *LRU[K]) Resize(size int) (evicted int) {
 	diff := c.Len() - size
 	if diff < 0 {
 		diff = 0
@@ -159,7 +161,7 @@ func (c *LRU) Resize(size int) (evicted int) {
 }
 
 // removeOldest removes the oldest item from the cache.
-func (c *LRU) removeOldest() {
+func (c *LRU[K]) removeOldest() {
 	ent := c.evictList.Back()
 	if ent != nil {
 		c.removeElement(ent)
@@ -167,9 +169,9 @@ func (c *LRU) removeOldest() {
 }
 
 // removeElement is used to remove a given list element from the cache
-func (c *LRU) removeElement(e *list.Element) {
+func (c *LRU[K]) removeElement(e *list.Element) {
 	c.evictList.Remove(e)
-	kv := e.Value.(*entry)
+	kv := e.Value.(*entry[K])
 	delete(c.items, kv.key)
 	if c.onEvict != nil {
 		c.onEvict(kv.key, kv.value)

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -6,20 +6,20 @@ import (
 )
 
 // EvictCallback is used to get a callback when a cache entry is evicted
-type EvictCallback func(key interface{}, value interface{})
+type EvictCallback func(key any, value any)
 
 // LRU implements a non-thread safe fixed size LRU cache
 type LRU struct {
 	size      int
 	evictList *list.List
-	items     map[interface{}]*list.Element
+	items     map[any]*list.Element
 	onEvict   EvictCallback
 }
 
 // entry is used to hold a value in the evictList
 type entry struct {
-	key   interface{}
-	value interface{}
+	key   any
+	value any
 }
 
 // NewLRU constructs an LRU of the given size
@@ -30,7 +30,7 @@ func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
 	c := &LRU{
 		size:      size,
 		evictList: list.New(),
-		items:     make(map[interface{}]*list.Element),
+		items:     make(map[any]*list.Element),
 		onEvict:   onEvict,
 	}
 	return c, nil
@@ -48,7 +48,7 @@ func (c *LRU) Purge() {
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occurred.
-func (c *LRU) Add(key, value interface{}) (evicted bool) {
+func (c *LRU) Add(key, value any) (evicted bool) {
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
@@ -70,7 +70,7 @@ func (c *LRU) Add(key, value interface{}) (evicted bool) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
+func (c *LRU) Get(key any) (value any, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
 		if ent.Value.(*entry) == nil {
@@ -83,14 +83,14 @@ func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 
 // Contains checks if a key is in the cache, without updating the recent-ness
 // or deleting it for being stale.
-func (c *LRU) Contains(key interface{}) (ok bool) {
+func (c *LRU) Contains(key any) (ok bool) {
 	_, ok = c.items[key]
 	return ok
 }
 
 // Peek returns the key value (or undefined if not found) without updating
 // the "recently used"-ness of the key.
-func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+func (c *LRU) Peek(key any) (value any, ok bool) {
 	var ent *list.Element
 	if ent, ok = c.items[key]; ok {
 		return ent.Value.(*entry).value, true
@@ -100,7 +100,7 @@ func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
 
 // Remove removes the provided key from the cache, returning if the
 // key was contained.
-func (c *LRU) Remove(key interface{}) (present bool) {
+func (c *LRU) Remove(key any) (present bool) {
 	if ent, ok := c.items[key]; ok {
 		c.removeElement(ent)
 		return true
@@ -109,7 +109,7 @@ func (c *LRU) Remove(key interface{}) (present bool) {
 }
 
 // RemoveOldest removes the oldest item from the cache.
-func (c *LRU) RemoveOldest() (key, value interface{}, ok bool) {
+func (c *LRU) RemoveOldest() (key, value any, ok bool) {
 	ent := c.evictList.Back()
 	if ent != nil {
 		c.removeElement(ent)
@@ -120,7 +120,7 @@ func (c *LRU) RemoveOldest() (key, value interface{}, ok bool) {
 }
 
 // GetOldest returns the oldest entry
-func (c *LRU) GetOldest() (key, value interface{}, ok bool) {
+func (c *LRU) GetOldest() (key, value any, ok bool) {
 	ent := c.evictList.Back()
 	if ent != nil {
 		kv := ent.Value.(*entry)
@@ -130,8 +130,8 @@ func (c *LRU) GetOldest() (key, value interface{}, ok bool) {
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
-func (c *LRU) Keys() []interface{} {
-	keys := make([]interface{}, len(c.items))
+func (c *LRU) Keys() []any {
+	keys := make([]any, len(c.items))
 	i := 0
 	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
 		keys[i] = ent.Value.(*entry).key

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -5,29 +5,29 @@ package simplelru
 type LRUCache interface {
 	// Adds a value to the cache, returns true if an eviction occurred and
 	// updates the "recently used"-ness of the key.
-	Add(key, value interface{}) bool
+	Add(key, value any) bool
 
 	// Returns key's value from the cache and
 	// updates the "recently used"-ness of the key. #value, isFound
-	Get(key interface{}) (value interface{}, ok bool)
+	Get(key any) (value any, ok bool)
 
 	// Checks if a key exists in cache without updating the recent-ness.
-	Contains(key interface{}) (ok bool)
+	Contains(key any) (ok bool)
 
 	// Returns key's value without updating the "recently used"-ness of the key.
-	Peek(key interface{}) (value interface{}, ok bool)
+	Peek(key any) (value any, ok bool)
 
 	// Removes a key from the cache.
-	Remove(key interface{}) bool
+	Remove(key any) bool
 
 	// Removes the oldest entry from cache.
-	RemoveOldest() (interface{}, interface{}, bool)
+	RemoveOldest() (any, any, bool)
 
 	// Returns the oldest entry from the cache. #key, value, isFound
-	GetOldest() (interface{}, interface{}, bool)
+	GetOldest() (any, any, bool)
 
 	// Returns a slice of the keys in the cache, from oldest to newest.
-	Keys() []interface{}
+	Keys() []any
 
 	// Returns the number of items in the cache.
 	Len() int

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -2,39 +2,39 @@
 package simplelru
 
 // LRUCache is the interface for simple LRU cache.
-type LRUCache interface {
-	// Adds a value to the cache, returns true if an eviction occurred and
+type LRUCache[K comparable] interface {
+	// Add adds a value to the cache, returns true if an eviction occurred and
 	// updates the "recently used"-ness of the key.
-	Add(key, value any) bool
+	Add(key K, value any) bool
 
-	// Returns key's value from the cache and
+	// Get returns key's value from the cache and
 	// updates the "recently used"-ness of the key. #value, isFound
-	Get(key any) (value any, ok bool)
+	Get(key K) (value any, ok bool)
 
-	// Checks if a key exists in cache without updating the recent-ness.
-	Contains(key any) (ok bool)
+	// Contains checks if a key exists in cache without updating the recent-ness.
+	Contains(key K) (ok bool)
 
-	// Returns key's value without updating the "recently used"-ness of the key.
-	Peek(key any) (value any, ok bool)
+	// Peek returns key's value without updating the "recently used"-ness of the key.
+	Peek(key K) (value any, ok bool)
 
-	// Removes a key from the cache.
-	Remove(key any) bool
+	// Remove removes a key from the cache.
+	Remove(key K) bool
 
-	// Removes the oldest entry from cache.
-	RemoveOldest() (any, any, bool)
+	// RemoveOldest removes the oldest entry from cache.
+	RemoveOldest() (K, any, bool)
 
-	// Returns the oldest entry from the cache. #key, value, isFound
-	GetOldest() (any, any, bool)
+	// GetOldest returns the oldest entry from the cache. #key, value, isFound
+	GetOldest() (K, any, bool)
 
-	// Returns a slice of the keys in the cache, from oldest to newest.
-	Keys() []any
+	// Keys returns a slice of the keys in the cache, from oldest to newest.
+	Keys() []K
 
-	// Returns the number of items in the cache.
+	// Len returns the number of items in the cache.
 	Len() int
 
-	// Clears all cache entries.
+	// Purge clears all cache entries.
 	Purge()
 
-	// Resizes cache, returning number evicted
+	// Resize resizes cache, returning number evicted
 	Resize(int) int
 }

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -2,29 +2,29 @@
 package simplelru
 
 // LRUCache is the interface for simple LRU cache.
-type LRUCache[K comparable] interface {
+type LRUCache[K comparable, V any] interface {
 	// Add adds a value to the cache, returns true if an eviction occurred and
 	// updates the "recently used"-ness of the key.
-	Add(key K, value any) bool
+	Add(key K, value V) bool
 
 	// Get returns key's value from the cache and
 	// updates the "recently used"-ness of the key. #value, isFound
-	Get(key K) (value any, ok bool)
+	Get(key K) (value V, ok bool)
 
 	// Contains checks if a key exists in cache without updating the recent-ness.
 	Contains(key K) (ok bool)
 
 	// Peek returns key's value without updating the "recently used"-ness of the key.
-	Peek(key K) (value any, ok bool)
+	Peek(key K) (value V, ok bool)
 
 	// Remove removes a key from the cache.
 	Remove(key K) bool
 
 	// RemoveOldest removes the oldest entry from cache.
-	RemoveOldest() (K, any, bool)
+	RemoveOldest() (K, V, bool)
 
 	// GetOldest returns the oldest entry from the cache. #key, value, isFound
-	GetOldest() (K, any, bool)
+	GetOldest() (K, V, bool)
 
 	// Keys returns a slice of the keys in the cache, from oldest to newest.
 	Keys() []K

--- a/simplelru/lru_test.go
+++ b/simplelru/lru_test.go
@@ -4,13 +4,13 @@ import "testing"
 
 func TestLRU(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k int, v any) {
-		if k != v.(int) {
-			t.Fatalf("Evict values not equal (%d!=%d)", k, v.(int))
+	onEvicted := func(k int, v int) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%d!=%d)", k, v)
 		}
 		evictCounter++
 	}
-	l, err := NewLRU[int](128, onEvicted)
+	l, err := NewLRU[int, int](128, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestLRU(t *testing.T) {
 }
 
 func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
-	l, err := NewLRU[int](128, nil)
+	l, err := NewLRU[int, int](128, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -111,11 +111,11 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 // Test that Add returns true/false if an eviction occurred
 func TestLRU_Add(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k int, v any) {
+	onEvicted := func(k int, v int) {
 		evictCounter++
 	}
 
-	l, err := NewLRU[int](1, onEvicted)
+	l, err := NewLRU[int, int](1, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestLRU_Add(t *testing.T) {
 
 // Test that Contains doesn't update recent-ness
 func TestLRU_Contains(t *testing.T) {
-	l, err := NewLRU[int](2, nil)
+	l, err := NewLRU[int, int](2, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestLRU_Contains(t *testing.T) {
 
 // Test that Peek doesn't update recent-ness
 func TestLRU_Peek(t *testing.T) {
-	l, err := NewLRU[int](2, nil)
+	l, err := NewLRU[int, int](2, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -169,10 +169,10 @@ func TestLRU_Peek(t *testing.T) {
 // Test that Resize can upsize and downsize
 func TestLRU_Resize(t *testing.T) {
 	onEvictCounter := 0
-	onEvicted := func(k int, v any) {
+	onEvicted := func(k int, v int) {
 		onEvictCounter++
 	}
-	l, err := NewLRU[int](2, onEvicted)
+	l, err := NewLRU[int, int](2, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/simplelru/lru_test.go
+++ b/simplelru/lru_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestLRU(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
+	onEvicted := func(k any, v any) {
 		if k != v {
 			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
 		}
@@ -111,7 +111,7 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 // Test that Add returns true/false if an eviction occurred
 func TestLRU_Add(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
+	onEvicted := func(k any, v any) {
 		evictCounter++
 	}
 
@@ -169,7 +169,7 @@ func TestLRU_Peek(t *testing.T) {
 // Test that Resize can upsize and downsize
 func TestLRU_Resize(t *testing.T) {
 	onEvictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
+	onEvicted := func(k any, v any) {
 		onEvictCounter++
 	}
 	l, err := NewLRU(2, onEvicted)

--- a/simplelru/lru_test.go
+++ b/simplelru/lru_test.go
@@ -4,13 +4,13 @@ import "testing"
 
 func TestLRU(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k any, v any) {
-		if k != v {
-			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+	onEvicted := func(k int, v any) {
+		if k != v.(int) {
+			t.Fatalf("Evict values not equal (%d!=%d)", k, v.(int))
 		}
 		evictCounter++
 	}
-	l, err := NewLRU(128, onEvicted)
+	l, err := NewLRU[int](128, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestLRU(t *testing.T) {
 }
 
 func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
-	l, err := NewLRU(128, nil)
+	l, err := NewLRU[int](128, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing")
 	}
-	if k.(int) != 128 {
+	if k != 128 {
 		t.Fatalf("bad: %v", k)
 	}
 
@@ -95,7 +95,7 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing")
 	}
-	if k.(int) != 128 {
+	if k != 128 {
 		t.Fatalf("bad: %v", k)
 	}
 
@@ -103,7 +103,7 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing")
 	}
-	if k.(int) != 129 {
+	if k != 129 {
 		t.Fatalf("bad: %v", k)
 	}
 }
@@ -111,11 +111,11 @@ func TestLRU_GetOldest_RemoveOldest(t *testing.T) {
 // Test that Add returns true/false if an eviction occurred
 func TestLRU_Add(t *testing.T) {
 	evictCounter := 0
-	onEvicted := func(k any, v any) {
+	onEvicted := func(k int, v any) {
 		evictCounter++
 	}
 
-	l, err := NewLRU(1, onEvicted)
+	l, err := NewLRU[int](1, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestLRU_Add(t *testing.T) {
 
 // Test that Contains doesn't update recent-ness
 func TestLRU_Contains(t *testing.T) {
-	l, err := NewLRU(2, nil)
+	l, err := NewLRU[int](2, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestLRU_Contains(t *testing.T) {
 
 // Test that Peek doesn't update recent-ness
 func TestLRU_Peek(t *testing.T) {
-	l, err := NewLRU(2, nil)
+	l, err := NewLRU[int](2, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -169,10 +169,10 @@ func TestLRU_Peek(t *testing.T) {
 // Test that Resize can upsize and downsize
 func TestLRU_Resize(t *testing.T) {
 	onEvictCounter := 0
-	onEvicted := func(k any, v any) {
+	onEvicted := func(k int, v any) {
 		onEvictCounter++
 	}
-	l, err := NewLRU(2, onEvicted)
+	l, err := NewLRU[int](2, onEvicted)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
one downside is the module now require Golang 1.18 and above
feel free to review and merge it whenever suitable