### PR TITLE
Add expirable LRU implementation, with generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,74 @@ Documentation
 
 Full docs are available on [Go Packages](https://pkg.go.dev/github.com/hashicorp/golang-lru/v2)
 
-Example
-=======
-
-Using the LRU is very simple:
+LRU cache example
+=================
 
 ```go
-l, _ := New(128)
-for i := 0; i < 256; i++ {
-    l.Add(i, nil)
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/golang-lru/v2"
+)
+
+func main() {
+	l, _ := lru.New[int, *string](128)
+	for i := 0; i < 256; i++ {
+		l.Add(i, nil)
+	}
+
+	if l.Len() != 128 {
+		panic(fmt.Sprintf("bad len: %v", l.Len()))
+	}
 }
-if l.Len() != 128 {
-    panic(fmt.Sprintf("bad len: %v", l.Len()))
+```
+
+Expirable LRU cache example
+===========================
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+func main() {
+	// make cache with short TTL and 3 max keys, purgeEvery time.Millisecond * 10
+	cache := simplelru.NewExpirableLRU[string, string](3, nil, time.Millisecond*5, time.Millisecond*10)
+	// expirable cache need to be closed after used
+	defer cache.Close()
+
+	// set value under key1.
+	cache.Add("key1", "val1")
+
+	// get value under key1
+	r, ok := cache.Get("key1")
+
+	// check for OK value
+	if ok {
+		fmt.Printf("value before expiration is found: %v, value: %q\n", ok, r)
+	}
+
+	// wait for cache to expire
+	time.Sleep(time.Millisecond * 16)
+
+	// get value under key1 after key expiration
+	r, ok = cache.Get("key1")
+	fmt.Printf("value after expiration is found: %v, value: %q\n", ok, r)
+
+	// set value under key2, would evict old entry because it is already expired.
+	cache.Add("key2", "val2")
+
+	fmt.Printf("Cache len: %d\n", cache.Len())
+	// Output:
+	// value before expiration is found: true, value: "val1"
+	// value after expiration is found: false, value: ""
+	// Cache len: 1
 }
 ```

--- a/simplelru/list.go
+++ b/simplelru/list.go
@@ -4,6 +4,8 @@
 
 package simplelru
 
+import "time"
+
 // entry is an LRU entry
 type entry[K comparable, V any] struct {
 	// Next and previous pointers in the doubly-linked list of elements.
@@ -21,6 +23,9 @@ type entry[K comparable, V any] struct {
 
 	// The value stored with this element.
 	value V
+
+	// The time this element would be cleaned up
+	expiresAt time.Time
 }
 
 // prevEntry returns the previous list element or nil.
@@ -79,9 +84,9 @@ func (l *lruList[K, V]) insert(e, at *entry[K, V]) *entry[K, V] {
 	return e
 }
 
-// insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
-func (l *lruList[K, V]) insertValue(k K, v V, at *entry[K, V]) *entry[K, V] {
-	return l.insert(&entry[K, V]{value: v, key: k}, at)
+// insertValue is a convenience wrapper for insert(&entry{value: v, expiresAt: expiresAt}, at).
+func (l *lruList[K, V]) insertValue(k K, v V, expiresAt time.Time, at *entry[K, V]) *entry[K, V] {
+	return l.insert(&entry[K, V]{value: v, key: k, expiresAt: expiresAt}, at)
 }
 
 // remove removes e from its list, decrements l.len
@@ -111,9 +116,9 @@ func (l *lruList[K, V]) move(e, at *entry[K, V]) {
 }
 
 // pushFront inserts a new element e with value v at the front of list l and returns e.
-func (l *lruList[K, V]) pushFront(k K, v V) *entry[K, V] {
+func (l *lruList[K, V]) pushFront(k K, v V, expiresAt time.Time) *entry[K, V] {
 	l.lazyInit()
-	return l.insertValue(k, v, &l.root)
+	return l.insertValue(k, v, expiresAt, &l.root)
 }
 
 // moveToFront moves element e to the front of list l.

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -2,20 +2,32 @@ package simplelru
 
 import (
 	"errors"
+	"sync"
+	"time"
 )
+
+// noEvictionTTL - very long ttl to prevent eviction
+const noEvictionTTL = time.Hour * 24 * 365 * 10
 
 // EvictCallback is used to get a callback when a cache entry is evicted
 type EvictCallback[K comparable, V any] func(key K, value V)
 
-// LRU implements a non-thread safe fixed size LRU cache
+// LRU implements a thread-safe safe fixed size LRU cache
+// or expirable cache if expirable creation function was used.
 type LRU[K comparable, V any] struct {
 	size      int
 	evictList *lruList[K, V]
 	items     map[K]*entry[K, V]
 	onEvict   EvictCallback[K, V]
+
+	// expirable options
+	mu         sync.Mutex
+	purgeEvery time.Duration
+	ttl        time.Duration
+	done       chan struct{}
 }
 
-// NewLRU constructs an LRU of the given size
+// NewLRU constructs a thread safe LRU of the given size
 func NewLRU[K comparable, V any](size int, onEvict EvictCallback[K, V]) (*LRU[K, V], error) {
 	if size <= 0 {
 		return nil, errors.New("must provide a positive size")
@@ -26,12 +38,64 @@ func NewLRU[K comparable, V any](size int, onEvict EvictCallback[K, V]) (*LRU[K,
 		evictList: newList[K, V](),
 		items:     make(map[K]*entry[K, V]),
 		onEvict:   onEvict,
+		ttl:       noEvictionTTL,
 	}
 	return c, nil
 }
 
-// Purge is used to completely clear the cache.
+// NewExpirableLRU returns a new thread-safe cache with expirable entries.
+//
+// Size parameter set to 0 makes cache of unlimited size, e.g. turns LRU off.
+//
+// Providing 0 TTL turns expiring off.
+//
+// Activates deleteExpired by purgeEvery duration.
+// If MaxKeys and TTL are defined and PurgeEvery is zero, PurgeEvery will be set to 5 minutes.
+func NewExpirableLRU[K comparable, V any](size int, onEvict EvictCallback[K, V], ttl, purgeEvery time.Duration) *LRU[K, V] {
+	if size < 0 {
+		size = 0
+	}
+	if ttl <= 0 {
+		ttl = noEvictionTTL
+	}
+
+	res := LRU[K, V]{
+		items:      make(map[K]*entry[K, V]),
+		evictList:  newList[K, V](),
+		ttl:        ttl,
+		purgeEvery: purgeEvery,
+		size:       size,
+		onEvict:    onEvict,
+		done:       make(chan struct{}),
+	}
+
+	// enable deleteExpired() running in separate goroutine for cache
+	// with non-zero TTL and size defined
+	if res.ttl != noEvictionTTL && (res.size > 0 || res.purgeEvery > 0) {
+		if res.purgeEvery <= 0 {
+			res.purgeEvery = time.Minute * 5 // non-zero purge enforced because size defined
+		}
+		go func(done <-chan struct{}) {
+			ticker := time.NewTicker(res.purgeEvery)
+			for {
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+					res.mu.Lock()
+					res.deleteExpired()
+					res.mu.Unlock()
+				}
+			}
+		}(res.done)
+	}
+	return &res
+}
+
+// Purge clears the cache completely.
 func (c *LRU[K, V]) Purge() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for k, v := range c.items {
 		if c.onEvict != nil {
 			c.onEvict(k, v.value)
@@ -41,30 +105,40 @@ func (c *LRU[K, V]) Purge() {
 	c.evictList.init()
 }
 
-// Add adds a value to the cache.  Returns true if an eviction occurred.
+// Add adds a value to the cache. Returns true if an eviction occurred.
 func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {
 		c.evictList.moveToFront(ent)
 		ent.value = value
+		ent.expiresAt = now.Add(c.ttl)
 		return false
 	}
 
 	// Add new item
-	ent := c.evictList.pushFront(key, value)
-	c.items[key] = ent
+	c.items[key] = c.evictList.pushFront(key, value, now.Add(c.ttl))
 
-	evict := c.evictList.length() > c.size
 	// Verify size not exceeded
-	if evict {
+	if c.size > 0 && len(c.items) > c.size {
 		c.removeOldest()
+		return true
 	}
-	return evict
+	return false
 }
 
 // Get looks up a key's value from the cache.
 func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
-	if ent, ok := c.items[key]; ok {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ent, found := c.items[key]; found {
+		// Expired item check
+		if time.Now().After(ent.expiresAt) {
+			return
+		}
 		c.evictList.moveToFront(ent)
 		return ent.value, true
 	}
@@ -74,6 +148,8 @@ func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
 // Contains checks if a key is in the cache, without updating the recent-ness
 // or deleting it for being stale.
 func (c *LRU[K, V]) Contains(key K) (ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	_, ok = c.items[key]
 	return ok
 }
@@ -81,8 +157,13 @@ func (c *LRU[K, V]) Contains(key K) (ok bool) {
 // Peek returns the key value (or undefined if not found) without updating
 // the "recently used"-ness of the key.
 func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
-	var ent *entry[K, V]
-	if ent, ok = c.items[key]; ok {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ent, found := c.items[key]; found {
+		// Expired item check
+		if time.Now().After(ent.expiresAt) {
+			return
+		}
 		return ent.value, true
 	}
 	return
@@ -90,7 +171,9 @@ func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
 
 // Remove removes the provided key from the cache, returning if the
 // key was contained.
-func (c *LRU[K, V]) Remove(key K) (present bool) {
+func (c *LRU[K, V]) Remove(key K) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if ent, ok := c.items[key]; ok {
 		c.removeElement(ent)
 		return true
@@ -100,6 +183,8 @@ func (c *LRU[K, V]) Remove(key K) (present bool) {
 
 // RemoveOldest removes the oldest item from the cache.
 func (c *LRU[K, V]) RemoveOldest() (key K, value V, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if ent := c.evictList.back(); ent != nil {
 		c.removeElement(ent)
 		return ent.key, ent.value, true
@@ -109,6 +194,8 @@ func (c *LRU[K, V]) RemoveOldest() (key K, value V, ok bool) {
 
 // GetOldest returns the oldest entry
 func (c *LRU[K, V]) GetOldest() (key K, value V, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if ent := c.evictList.back(); ent != nil {
 		return ent.key, ent.value, true
 	}
@@ -117,23 +204,27 @@ func (c *LRU[K, V]) GetOldest() (key K, value V, ok bool) {
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
 func (c *LRU[K, V]) Keys() []K {
-	keys := make([]K, c.evictList.length())
-	i := 0
-	for ent := c.evictList.back(); ent != nil; ent = ent.prevEntry() {
-		keys[i] = ent.key
-		i++
-	}
-	return keys
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.keys()
 }
 
 // Len returns the number of items in the cache.
 func (c *LRU[K, V]) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.evictList.length()
 }
 
-// Resize changes the cache size.
+// Resize changes the cache size. Size of 0 doesn't resize the cache, as it means unlimited.
 func (c *LRU[K, V]) Resize(size int) (evicted int) {
-	diff := c.Len() - size
+	if size <= 0 {
+		c.size = 0
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	diff := c.evictList.length() - size
 	if diff < 0 {
 		diff = 0
 	}
@@ -144,18 +235,45 @@ func (c *LRU[K, V]) Resize(size int) (evicted int) {
 	return diff
 }
 
-// removeOldest removes the oldest item from the cache.
+// Close cleans the cache and destroys running goroutines for expirable cache,
+// and does nothing for non-expirable one.
+func (c *LRU[K, V]) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	close(c.done)
+}
+
+// removeOldest removes the oldest item from the cache. Has to be called with lock!
 func (c *LRU[K, V]) removeOldest() {
 	if ent := c.evictList.back(); ent != nil {
 		c.removeElement(ent)
 	}
 }
 
-// removeElement is used to remove a given list element from the cache
+// removeElement is used to remove a given list element from the cache. Has to be called with lock!
 func (c *LRU[K, V]) removeElement(e *entry[K, V]) {
 	c.evictList.remove(e)
 	delete(c.items, e.key)
 	if c.onEvict != nil {
 		c.onEvict(e.key, e.value)
 	}
+}
+
+// deleteExpired deletes expired records. Has to be called with lock!
+func (c *LRU[K, V]) deleteExpired() {
+	for _, key := range c.keys() {
+		if time.Now().After(c.items[key].expiresAt) {
+			c.removeElement(c.items[key])
+			continue
+		}
+	}
+}
+
+// keys returns a slice of the keys in the cache, from oldest to newest. Has to be called with lock!
+func (c *LRU[K, V]) keys() []K {
+	keys := make([]K, 0, len(c.items))
+	for ent := c.evictList.back(); ent != nil; ent = ent.prevEntry() {
+		keys = append(keys, ent.key)
+	}
+	return keys
 }

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -35,6 +35,9 @@ type LRUCache[K comparable, V any] interface {
 	// Clears all cache entries.
 	Purge()
 
+	// Closes all hanging goroutines.
+	Close()
+
 	// Resizes cache, returning number evicted
 	Resize(int) int
 }


### PR DESCRIPTION
My attempt at expirable cache implementation is similar to what was done in #41. I've tried to make the new cache as close as possible to the existing one regarding code style and behaviour.

The only difference I left in place is that `size=0` on this type of cache means _unlimited_, which makes sense with the expirable cache.

Original work was done in [lcw](https://github.com/paskal/lcw/tree/lru_internal), but it turned out that I don't need it there, and I thought it would be nice to add my changes to upstream (this repo).

This PR is a recreation of #68, which was not merged. cc @jefferai @Dentrax for review.