### PR TITLE
Reduce memory usage by not storing ghost values

### DIFF
--- a/2q.go
+++ b/2q.go
@@ -32,7 +32,7 @@ type TwoQueueCache[K comparable, V any] struct {
 
 	recent      simplelru.LRUCache[K, V]
 	frequent    simplelru.LRUCache[K, V]
-	recentEvict simplelru.LRUCache[K, V]
+	recentEvict simplelru.LRUCache[K, struct{}]
 	lock        sync.RWMutex
 }
 
@@ -68,7 +68,7 @@ func New2QParams[K comparable, V any](size int, recentRatio, ghostRatio float64)
 	if err != nil {
 		return nil, err
 	}
-	recentEvict, err := simplelru.NewLRU[K, V](evictSize, nil)
+	recentEvict, err := simplelru.NewLRU[K, struct{}](evictSize, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +153,7 @@ func (c *TwoQueueCache[K, V]) ensureSpace(recentEvict bool) {
 	// the target, evict from there
 	if recentLen > 0 && (recentLen > c.recentSize || (recentLen == c.recentSize && !recentEvict)) {
 		k, _, _ := c.recent.RemoveOldest()
-		var empty V
-		c.recentEvict.Add(k, empty)
+		c.recentEvict.Add(k, struct{}{})
 		return
 	}
 

--- a/arc.go
+++ b/arc.go
@@ -18,11 +18,11 @@ type ARCCache[K comparable, V any] struct {
 	size int // Size is the total capacity of the cache
 	p    int // P is the dynamic preference towards T1 or T2
 
-	t1 simplelru.LRUCache[K, V] // T1 is the LRU for recently accessed items
-	b1 simplelru.LRUCache[K, V] // B1 is the LRU for evictions from t1
+	t1 simplelru.LRUCache[K, V]        // T1 is the LRU for recently accessed items
+	b1 simplelru.LRUCache[K, struct{}] // B1 is the LRU for evictions from t1
 
-	t2 simplelru.LRUCache[K, V] // T2 is the LRU for frequently accessed items
-	b2 simplelru.LRUCache[K, V] // B2 is the LRU for evictions from t2
+	t2 simplelru.LRUCache[K, V]        // T2 is the LRU for frequently accessed items
+	b2 simplelru.LRUCache[K, struct{}] // B2 is the LRU for evictions from t2
 
 	lock sync.RWMutex
 }
@@ -30,11 +30,11 @@ type ARCCache[K comparable, V any] struct {
 // NewARC creates an ARC of the given size
 func NewARC[K comparable, V any](size int) (*ARCCache[K, V], error) {
 	// Create the sub LRUs
-	b1, err := simplelru.NewLRU[K, V](size, nil)
+	b1, err := simplelru.NewLRU[K, struct{}](size, nil)
 	if err != nil {
 		return nil, err
 	}
-	b2, err := simplelru.NewLRU[K, V](size, nil)
+	b2, err := simplelru.NewLRU[K, struct{}](size, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -182,14 +182,12 @@ func (c *ARCCache[K, V]) replace(b2ContainsKey bool) {
 	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
 		k, _, ok := c.t1.RemoveOldest()
 		if ok {
-			var empty V
-			c.b1.Add(k, empty)
+			c.b1.Add(k, struct{}{})
 		}
 	} else {
 		k, _, ok := c.t2.RemoveOldest()
 		if ok {
-			var empty V
-			c.b2.Add(k, empty)
+			c.b2.Add(k, struct{}{})
 		}
 	}
 }


### PR DESCRIPTION
Keeping ghost values is needed, so replace `empty` values with `struct{}{}` to save space.