### PR TITLE
Fix nil panic on remove

### DIFF
--- a/simplelru/list.go
+++ b/simplelru/list.go
@@ -86,13 +86,14 @@ func (l *lruList[K, V]) insertValue(k K, v V, at *entry[K, V]) *entry[K, V] {
 
 // remove removes e from its list, decrements l.len
 func (l *lruList[K, V]) remove(e *entry[K, V]) V {
-	e.prev.next = e.next
-	e.next.prev = e.prev
-	e.next = nil // avoid memory leaks
-	e.prev = nil // avoid memory leaks
-	e.list = nil
-	l.len--
-
+	if e.list == l {
+		e.prev.next = e.next
+		e.next.prev = e.prev
+		e.next = nil // avoid memory leaks
+		e.prev = nil // avoid memory leaks
+		e.list = nil
+		l.len--
+	}
 	return e.value
 }
 


### PR DESCRIPTION
Fix for panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6e4a5de]
goroutine 444 [running]:
github.com/hashicorp/golang-lru/v2/simplelru.(*lruList[...]).remove(...)
	github.com/hashicorp/golang-lru/v2@v2.0.2/simplelru/list.go:89
github.com/hashicorp/golang-lru/v2/simplelru.(*LRU[...]).removeElement(0xc002244180?, 0xc0e49d408c?)
	github.com/hashicorp/golang-lru/v2@v2.0.2/simplelru/lru.go:159 +0x1e
github.com/hashicorp/golang-lru/v2/simplelru.(*LRU[...]).Remove(0xc19b580, {0xc0e49d408c, 0x547e17?})
	github.com/hashicorp/golang-lru/v2@v2.0.2/simplelru/lru.go:98 +0x57
github.com/hashicorp/golang-lru/v2.(*Cache[...]).Remove(0xc1950c0, {0xc0e49d408c, 0xc})
	github.com/hashicorp/golang-lru/v2@v2.0.2/lru.go:172 +0x5f
```
Not really sure how this panic happens and I can only reproduce it in a high concurrent environment. From what I can tell the panic happens when `e.prev` is `nil` and the only time `e.prev` is set to nil is when it's being removed from the list. `removeElement` is suppose to delete the key from items map in `LRU`, but somehow we still seem to get the entry back. If it is an entry we've already removed, the list would be set to `nil`, adding a condition to check if entry has the correct list would avoid this panic.

Go version: 1.20.3/1.20.2