### PR TITLE
Fix benchmarks hit ratio display

### DIFF
--- a/2q_test.go
+++ b/2q_test.go
@@ -32,7 +32,7 @@ func Benchmark2Q_Rand(b *testing.B) {
 			}
 		}
 	}
-	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(hit+miss))
 }
 
 func Benchmark2Q_Freq(b *testing.B) {
@@ -63,7 +63,7 @@ func Benchmark2Q_Freq(b *testing.B) {
 			miss++
 		}
 	}
-	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(hit+miss))
 }
 
 func Test2Q_RandomOps(t *testing.T) {

--- a/arc_test.go
+++ b/arc_test.go
@@ -38,7 +38,7 @@ func BenchmarkARC_Rand(b *testing.B) {
 			}
 		}
 	}
-	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(hit+miss))
 }
 
 func BenchmarkARC_Freq(b *testing.B) {
@@ -69,7 +69,7 @@ func BenchmarkARC_Freq(b *testing.B) {
 			miss++
 		}
 	}
-	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(hit+miss))
 }
 
 func TestARC_RandomOps(t *testing.T) {

--- a/lru_test.go
+++ b/lru_test.go
@@ -32,7 +32,7 @@ func BenchmarkLRU_Rand(b *testing.B) {
 			}
 		}
 	}
-	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(hit+miss))
 }
 
 func BenchmarkLRU_Freq(b *testing.B) {
@@ -63,7 +63,7 @@ func BenchmarkLRU_Freq(b *testing.B) {
 			miss++
 		}
 	}
-	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(miss))
+	b.Logf("hit: %d miss: %d ratio: %f", hit, miss, float64(hit)/float64(hit+miss))
 }
 
 func TestLRU(t *testing.T) {


### PR DESCRIPTION
Was previously dividing hit by miss, should be dividing hit by total.