### PR TITLE
expirable LRU: fix so that Get/Peek cannot return an ok and empty value

### DIFF
--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -153,7 +153,7 @@ func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
 	if ent, ok = c.items[key]; ok {
 		// Expired item check
 		if time.Now().After(ent.ExpiresAt) {
-			return
+			return value, false
 		}
 		c.evictList.MoveToFront(ent)
 		return ent.Value, true
@@ -179,7 +179,7 @@ func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
 	if ent, ok = c.items[key]; ok {
 		// Expired item check
 		if time.Now().After(ent.ExpiresAt) {
-			return
+			return value, false
 		}
 		return ent.Value, true
 	}

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -390,7 +390,17 @@ func TestLoadingExpired(t *testing.T) {
 		t.Fatalf("should be true")
 	}
 
-	time.Sleep(time.Millisecond * 100) // wait for entry to expire
+	for {
+		result, ok := lc.Get("key1")
+		if ok && result == "" {
+			t.Fatalf("ok should return a result")
+		}
+		if !ok {
+			break
+		}
+	}
+
+	time.Sleep(time.Millisecond * 2) // wait for expiration reaper
 	if lc.Len() != 0 {
 		t.Fatalf("length differs from expected")
 	}

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -400,7 +400,7 @@ func TestLoadingExpired(t *testing.T) {
 		}
 	}
 
-	time.Sleep(time.Millisecond * 2) // wait for expiration reaper
+	time.Sleep(time.Millisecond * 100) // wait for expiration reaper
 	if lc.Len() != 0 {
 		t.Fatalf("length differs from expected")
 	}


### PR DESCRIPTION
Fixes #150 where if an item is expired and the expiration reaper hasn't run yet, we'd return true and an empty value