### PR TITLE
feat: Add RemoveWithoutEvict cache method

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -181,6 +181,15 @@ func (c *Cache[K, V]) Remove(key K) (present bool) {
 	return
 }
 
+// RemoveWithoutEvict removes the provided key from the cache without calling
+// the eviction callback.
+func (c *Cache[K, V]) RemoveWithoutEvict(key K) (present bool) {
+	c.lock.Lock()
+	present = c.lru.RemoveWithoutEvict(key)
+	c.lock.Unlock()
+	return
+}
+
 // Resize changes the cache size.
 func (c *Cache[K, V]) Resize(size int) (evicted int) {
 	var ks []K

--- a/lru_test.go
+++ b/lru_test.go
@@ -444,3 +444,35 @@ func TestCache_EvictionSameKey(t *testing.T) {
 		}
 	})
 }
+
+func TestLRURemoveWithoutEvict(t *testing.T) {
+	var (
+		called      bool
+		evictedKeys []int
+	)
+
+	cache, _ := NewWithEvict(2, func(key int, _ struct{}) {
+		called = true
+		evictedKeys = append(evictedKeys, key)
+	})
+
+	cache.Add(1, struct{}{})
+	cache.Add(2, struct{}{})
+
+	cache.Remove(1)
+	if !called {
+		t.Error("eviction wasn't called")
+	}
+
+	called = false
+
+	cache.RemoveWithoutEvict(2)
+	if called {
+		t.Error("eviction was called")
+	}
+
+	want := []int{1}
+	if !reflect.DeepEqual(evictedKeys, want) {
+		t.Errorf("evictedKeys got: %v want: %v", evictedKeys, want)
+	}
+}

--- a/simplelru/lru_interface.go
+++ b/simplelru/lru_interface.go
@@ -23,6 +23,9 @@ type LRUCache[K comparable, V any] interface {
 	// Removes a key from the cache.
 	Remove(key K) bool
 
+	// Removes a key from the cache without calling the eviction callback.
+	RemoveWithoutEvict(key K) bool
+
 	// Removes the oldest entry from cache.
 	RemoveOldest() (K, V, bool)
 


### PR DESCRIPTION
This PR adds the ability to remove elements from a cache without calling any configured eviction callback.

My use-case is I have a cache of non-trivial `io.ReadCloser` implementations and the eviction callback calls `Close()` on any "expired" entries. I want to be able to retrieve a cache entry and remove it from the cache to prevent another goroutine using it, however currently doing this calls `Close()` which then renders the `io.ReadCloser` unusable.

Fixes #171 