### PR TITLE
update LRU cache Get to use RLock

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -93,9 +93,9 @@ func (c *Cache[K, V]) Add(key K, value V) (evicted bool) {
 
 // Get looks up a key's value from the cache.
 func (c *Cache[K, V]) Get(key K) (value V, ok bool) {
-	c.lock.Lock()
+	c.lock.RLock()
 	value, ok = c.lru.Get(key)
-	c.lock.Unlock()
+	c.lock.RUnlock()
 	return value, ok
 }
 


### PR DESCRIPTION
Updates Get to use RLock / RUnlock on the RWMutex. 

This should significantly decrease lock contention in situations where we have many goroutines all trying to read from the cache. 