### PR TITLE
Add  @hashicorp/raft-force to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/team-ip-compliance
+* @hashicorp/team-ip-compliance @hashicorp/raft-force
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting


### PR DESCRIPTION
While not Raft-specific, this library is a dependency of hashicorp/go-immutable-radix which is used is in hashicorp/go-memdb which is most often used with hashicorp/raft and maintained by the  @hashicorp/raft-force team.