### PR TITLE
Use two step PR approval process for IP Compliance team members

### DIFF
--- a/.github/workflows/two-step-pr-approval.yml
+++ b/.github/workflows/two-step-pr-approval.yml
@@ -1,0 +1,20 @@
+name: Two-Stage PR Review Process
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  manage-pr-status:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Two stage PR review
+        uses: hashicorp/two-stage-pr-approval@v0.1.0


### PR DESCRIPTION
We have been instating this process to ensure that any PRs raised by IP compliance team members follows a comprehensive internal team review first and then become open for wider review for shared/core libraries that we co-own.
Memo for this change : https://go.hashi.co/memo/eng-001