### PR TITLE
feat(expirable): add GetAndRefresh to renew TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ func main() {
 	// make cache with 10ms TTL and 5 max keys
 	cache := expirable.NewLRU[string, string](5, nil, time.Millisecond*10)
 
-
 	// set value under key1.
 	cache.Add("key1", "val1")
 
-	// get value under key1
-	r, ok := cache.Get("key1")
+	// get value under key1 and renew its TTL.
+	r, ok := cache.GetAndRefresh("key1")
 
 	// check for OK value
 	if ok {

--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -147,6 +147,29 @@ func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
 	return
 }
 
+// GetAndRefresh looks up a key's value from the cache, updates the
+// "recently used"-ness of the key, and renews its expiration.
+func (c *LRU[K, V]) GetAndRefresh(key K) (value V, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ent, ok := c.items[key]
+	if !ok {
+		return value, false
+	}
+
+	now := time.Now()
+	if !c.cleanupStopped && now.After(ent.ExpiresAt) {
+		return value, false
+	}
+
+	c.evictList.MoveToFront(ent)
+	c.removeFromBucket(ent)
+	ent.ExpiresAt = now.Add(c.ttl)
+	c.addToBucket(ent)
+	return ent.Value, true
+}
+
 // Contains checks if a key is in the cache, without updating the recent-ness
 // or deleting it for being stale.
 func (c *LRU[K, V]) Contains(key K) (ok bool) {

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -622,3 +622,61 @@ func TestCache_RestartGoRoutine(t *testing.T) {
 		t.Errorf("expected keys to be empty")
 	}
 }
+
+func TestLRU_GetAndRefresh_RenewsTTL(t *testing.T) {
+	cache := NewLRU[string, string](2, nil, 80*time.Millisecond)
+
+	cache.Add("key1", "val1")
+
+	time.Sleep(50 * time.Millisecond)
+	v, ok := cache.GetAndRefresh("key1")
+	if !ok || v != "val1" {
+		t.Fatalf("expected refreshed key1 hit, got value=%q ok=%v", v, ok)
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	v, ok = cache.Get("key1")
+	if !ok || v != "val1" {
+		t.Fatalf("expected key1 to still be valid after refresh, got value=%q ok=%v", v, ok)
+	}
+}
+
+func TestLRU_GetAndRefresh_ExpiredDoesNotRevive(t *testing.T) {
+	cache := NewLRU[string, string](2, nil, 20*time.Millisecond)
+
+	cache.Add("key1", "val1")
+	time.Sleep(40 * time.Millisecond)
+
+	v, ok := cache.GetAndRefresh("key1")
+	if ok || v != "" {
+		t.Fatalf("expected expired key1 miss, got value=%q ok=%v", v, ok)
+	}
+
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for cache.Len() != 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if cache.Len() != 0 {
+		t.Fatalf("expected reaper to eventually remove expired key, got len=%d", cache.Len())
+	}
+}
+
+func TestLRU_GetAndRefresh_UpdatesRecency(t *testing.T) {
+	cache := NewLRU[string, string](2, nil, time.Hour)
+
+	cache.Add("key1", "val1")
+	cache.Add("key2", "val2")
+
+	v, ok := cache.GetAndRefresh("key1")
+	if !ok || v != "val1" {
+		t.Fatalf("expected refreshed key1 hit, got value=%q ok=%v", v, ok)
+	}
+
+	cache.Add("key3", "val3")
+	if cache.Contains("key2") {
+		t.Fatalf("expected key2 to be evicted as oldest")
+	}
+	if !cache.Contains("key1") || !cache.Contains("key3") {
+		t.Fatalf("expected key1 and key3 to remain in cache")
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces a new method in the `expirable` package,`GetAndRefresh`, to lookup up a key's value from the cache, update its "recently used"-ness, and renew its expiration.

## Related Issue

I need this for my usecase but might cover https://github.com/hashicorp/golang-lru/issues/186.

## How Has This Been Tested?

With included tests.