### PR TITLE
docs: make expirable LRU README example less flaky

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ func main() {
 		fmt.Printf("value before expiration is found: %v, value: %q\n", ok, r)
 	}
 
-	// wait for cache to expire
-	time.Sleep(time.Millisecond * 12)
+	// wait for cache to expire and for the periodic cleanup goroutine to run
+	time.Sleep(time.Millisecond * 100)
 
 	// get value under key1 after key expiration
 	r, ok = cache.Get("key1")


### PR DESCRIPTION
## Summary
- update the expirable LRU README example to wait long enough for the TTL to elapse and the periodic cleanup goroutine to run
- align the README example with the tested `ExampleLRU` timing in `expirable/expirable_lru_test.go`
- reduce the chance of readers reproducing issue #187 due to a too-short sleep interval

Closes #187

## Validation
- attempted: `go test ./expirable` *(not runnable in this environment because the Go toolchain is not installed)*
- ran a consistency check to verify the README example now matches the tested `ExampleLRU` sleep duration:
  - PowerShell check comparing `README.md` and `expirable/expirable_lru_test.go`