### PR TITLE
Prevent Values() panic due to index out of range

### DIFF
--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -133,7 +133,7 @@ func (c *LRU[K, V]) Keys() []K {
 
 // Values returns a slice of the values in the cache, from oldest to newest.
 func (c *LRU[K, V]) Values() []V {
-	values := make([]V, len(c.items))
+	values := make([]V, len(c.evictList.Length()))
 	i := 0
 	for ent := c.evictList.Back(); ent != nil; ent = ent.PrevEntry() {
 		values[i] = ent.Value

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -133,7 +133,7 @@ func (c *LRU[K, V]) Keys() []K {
 
 // Values returns a slice of the values in the cache, from oldest to newest.
 func (c *LRU[K, V]) Values() []V {
-	values := make([]V, len(c.evictList.Length()))
+	values := make([]V, c.evictList.Length())
 	i := 0
 	for ent := c.evictList.Back(); ent != nil; ent = ent.PrevEntry() {
 		values[i] = ent.Value


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

The size of `values` slice should match the number of items being iterated in `evictList`.

```
panic: runtime error: index out of range [119] with length 119
goroutine 1404 [running]:
github.com/hashicorp/golang-lru/v2/simplelru.(*LRU[...]).Values(...)
	github.com/hashicorp/golang-lru/v2@v2.0.7/simplelru/lru.go:139
```

## Related Issue

<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?

<!-- Describe how the changes have been tested. Provide test instructions or details. -->
