### PR TITLE
fix: drain full eviction buffer on Add/Remove paths

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -55,39 +55,54 @@ func (c *Cache[K, V]) onEvicted(k K, v V) {
 	c.evictedVals = append(c.evictedVals, v)
 }
 
+// takeEvictions returns and clears any buffered eviction entries.
+// Caller must hold c.lock.
+func (c *Cache[K, V]) takeEvictions() (ks []K, vs []V) {
+	if len(c.evictedKeys) == 0 {
+		return nil, nil
+	}
+	ks, vs = c.evictedKeys, c.evictedVals
+	c.initEvictBuffers()
+	return ks, vs
+}
+
+// invokeEvictions runs the user eviction callback outside the lock.
+func (c *Cache[K, V]) invokeEvictions(ks []K, vs []V) {
+	if c.onEvictedCB == nil {
+		return
+	}
+	for i := 0; i < len(ks); i++ {
+		c.onEvictedCB(ks[i], vs[i])
+	}
+}
+
 // Purge is used to completely clear the cache.
 func (c *Cache[K, V]) Purge() {
 	var ks []K
 	var vs []V
 	c.lock.Lock()
 	c.lru.Purge()
-	if c.onEvictedCB != nil && len(c.evictedKeys) > 0 {
-		ks, vs = c.evictedKeys, c.evictedVals
-		c.initEvictBuffers()
+	if c.onEvictedCB != nil {
+		ks, vs = c.takeEvictions()
 	}
 	c.lock.Unlock()
 	// invoke callback outside of critical section
-	if c.onEvictedCB != nil {
-		for i := 0; i < len(ks); i++ {
-			c.onEvictedCB(ks[i], vs[i])
-		}
-	}
+	c.invokeEvictions(ks, vs)
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
 func (c *Cache[K, V]) Add(key K, value V) (evicted bool) {
-	var k K
-	var v V
+	var ks []K
+	var vs []V
 	c.lock.Lock()
 	evicted = c.lru.Add(key, value)
-	if c.onEvictedCB != nil && evicted {
-		k, v = c.evictedKeys[0], c.evictedVals[0]
-		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	if c.onEvictedCB != nil {
+		// Drain the full eviction queue. Do not reset the whole buffer after
+		// only consuming the first entry (see #190).
+		ks, vs = c.takeEvictions()
 	}
 	c.lock.Unlock()
-	if c.onEvictedCB != nil && evicted {
-		c.onEvictedCB(k, v)
-	}
+	c.invokeEvictions(ks, vs)
 	return
 }
 
@@ -121,22 +136,19 @@ func (c *Cache[K, V]) Peek(key K) (value V, ok bool) {
 // recent-ness or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
 func (c *Cache[K, V]) ContainsOrAdd(key K, value V) (ok, evicted bool) {
-	var k K
-	var v V
+	var ks []K
+	var vs []V
 	c.lock.Lock()
 	if c.lru.Contains(key) {
 		c.lock.Unlock()
 		return true, false
 	}
 	evicted = c.lru.Add(key, value)
-	if c.onEvictedCB != nil && evicted {
-		k, v = c.evictedKeys[0], c.evictedVals[0]
-		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	if c.onEvictedCB != nil {
+		ks, vs = c.takeEvictions()
 	}
 	c.lock.Unlock()
-	if c.onEvictedCB != nil && evicted {
-		c.onEvictedCB(k, v)
-	}
+	c.invokeEvictions(ks, vs)
 	return false, evicted
 }
 
@@ -144,8 +156,8 @@ func (c *Cache[K, V]) ContainsOrAdd(key K, value V) (ok, evicted bool) {
 // recent-ness or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
 func (c *Cache[K, V]) PeekOrAdd(key K, value V) (previous V, ok, evicted bool) {
-	var k K
-	var v V
+	var ks []K
+	var vs []V
 	c.lock.Lock()
 	previous, ok = c.lru.Peek(key)
 	if ok {
@@ -153,31 +165,25 @@ func (c *Cache[K, V]) PeekOrAdd(key K, value V) (previous V, ok, evicted bool) {
 		return previous, true, false
 	}
 	evicted = c.lru.Add(key, value)
-	if c.onEvictedCB != nil && evicted {
-		k, v = c.evictedKeys[0], c.evictedVals[0]
-		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	if c.onEvictedCB != nil {
+		ks, vs = c.takeEvictions()
 	}
 	c.lock.Unlock()
-	if c.onEvictedCB != nil && evicted {
-		c.onEvictedCB(k, v)
-	}
+	c.invokeEvictions(ks, vs)
 	return
 }
 
 // Remove removes the provided key from the cache.
 func (c *Cache[K, V]) Remove(key K) (present bool) {
-	var k K
-	var v V
+	var ks []K
+	var vs []V
 	c.lock.Lock()
 	present = c.lru.Remove(key)
-	if c.onEvictedCB != nil && present {
-		k, v = c.evictedKeys[0], c.evictedVals[0]
-		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	if c.onEvictedCB != nil {
+		ks, vs = c.takeEvictions()
 	}
 	c.lock.Unlock()
-	if c.onEvictedCB != nil && present {
-		c.onEvictedCB(k, v)
-	}
+	c.invokeEvictions(ks, vs)
 	return
 }
 
@@ -188,32 +194,24 @@ func (c *Cache[K, V]) Resize(size int) (evicted int) {
 	c.lock.Lock()
 	evicted = c.lru.Resize(size)
 	if c.onEvictedCB != nil && evicted > 0 {
-		ks, vs = c.evictedKeys, c.evictedVals
-		c.initEvictBuffers()
+		ks, vs = c.takeEvictions()
 	}
 	c.lock.Unlock()
-	if c.onEvictedCB != nil && evicted > 0 {
-		for i := 0; i < len(ks); i++ {
-			c.onEvictedCB(ks[i], vs[i])
-		}
-	}
+	c.invokeEvictions(ks, vs)
 	return evicted
 }
 
 // RemoveOldest removes the oldest item from the cache.
 func (c *Cache[K, V]) RemoveOldest() (key K, value V, ok bool) {
-	var k K
-	var v V
+	var ks []K
+	var vs []V
 	c.lock.Lock()
 	key, value, ok = c.lru.RemoveOldest()
-	if c.onEvictedCB != nil && ok {
-		k, v = c.evictedKeys[0], c.evictedVals[0]
-		c.evictedKeys, c.evictedVals = c.evictedKeys[:0], c.evictedVals[:0]
+	if c.onEvictedCB != nil {
+		ks, vs = c.takeEvictions()
 	}
 	c.lock.Unlock()
-	if c.onEvictedCB != nil && ok {
-		c.onEvictedCB(k, v)
-	}
+	c.invokeEvictions(ks, vs)
 	return
 }
 

--- a/lru_test.go
+++ b/lru_test.go
@@ -4,6 +4,7 @@
 package lru
 
 import (
+	"sync"
 	"reflect"
 	"testing"
 )
@@ -443,4 +444,56 @@ func TestCache_EvictionSameKey(t *testing.T) {
 			t.Errorf("evictedKeys got: %v want: %v", evictedKeys, want)
 		}
 	})
+}
+
+
+// TestOnEvictDrainsAllBufferedEntries ensures eviction paths drain the full
+// buffered queue instead of keeping only the first entry and wiping the rest
+// (hashicorp/golang-lru#190).
+func TestOnEvictDrainsAllBufferedEntries(t *testing.T) {
+	var mu sync.Mutex
+	var got []int
+	onEvicted := func(k, v int) {
+		mu.Lock()
+		got = append(got, k)
+		mu.Unlock()
+		if k != v {
+			t.Errorf("evict key/value mismatch: %v != %v", k, v)
+		}
+	}
+
+	// Resize can buffer multiple evictions; all must be delivered.
+	c, err := NewWithEvict[int, int](2, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	c.Add(1, 1)
+	c.Add(2, 2)
+	if n := c.Resize(0); n != 2 {
+		t.Fatalf("Resize(0) evicted %d, want 2", n)
+	}
+	mu.Lock()
+	if len(got) != 2 {
+		t.Fatalf("Resize onEvict count=%d want 2; got=%v", len(got), got)
+	}
+	mu.Unlock()
+
+	// Sequential Add on a size-2 cache should fire once per capacity eviction.
+	got = got[:0]
+	c2, err := NewWithEvict[int, int](2, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	c2.Add(10, 10)
+	c2.Add(11, 11)
+	c2.Add(12, 12) // evicts 10
+	c2.Add(13, 13) // evicts 11
+	mu.Lock()
+	if len(got) != 2 {
+		t.Fatalf("sequential Add onEvict count=%d want 2; got=%v", len(got), got)
+	}
+	if got[0] != 10 || got[1] != 11 {
+		t.Fatalf("sequential Add onEvict order=%v want [10 11]", got)
+	}
+	mu.Unlock()
 }


### PR DESCRIPTION
## Summary
`Add` / `ContainsOrAdd` / `PeekOrAdd` / `Remove` / `RemoveOldest` took only `evictedKeys[0]` then reset the whole buffer with `[:0]`.

That is not a queue pop — any additional buffered eviction callbacks are discarded (reported in #190). `Purge` / `Resize` already drain the full buffer.

## Fix
- Take the full eviction buffer after each mutating op
- Invoke `onEvict` for every queued entry outside the lock
- Shared helpers: `takeEvictions` / `invokeEvictions`

Fixes #190

## Test plan
- [x] `go test .`
- [x] `TestOnEvictDrainsAllBufferedEntries`