### PR TITLE
fix(expirable): renew TTL on Get for sliding expiration

### DIFF
--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -132,16 +132,24 @@ func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 }
 
 // Get looks up a key's value from the cache.
+// A successful Get renews the entry's TTL (sliding expiration).
 func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	var ent *internal.Entry[K, V]
 	if ent, ok = c.items[key]; ok {
+		now := time.Now()
 		// Expired item check
-		if !c.cleanupStopped && time.Now().After(ent.ExpiresAt) {
+		if !c.cleanupStopped && now.After(ent.ExpiresAt) {
 			return value, false
 		}
 		c.evictList.MoveToFront(ent)
+		// Renew TTL on access so active keys do not expire while in use.
+		if c.ttl != noEvictionTTL {
+			c.removeFromBucket(ent)
+			ent.ExpiresAt = now.Add(c.ttl)
+			c.addToBucket(ent)
+		}
 		return ent.Value, true
 	}
 	return

--- a/expirable/get_refresh_test.go
+++ b/expirable/get_refresh_test.go
@@ -1,0 +1,21 @@
+package expirable
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetRefreshesTTL(t *testing.T) {
+	c := NewLRU[string, int](10, nil, 80*time.Millisecond)
+	c.Add("a", 1)
+	time.Sleep(50 * time.Millisecond)
+	if v, ok := c.Get("a"); !ok || v != 1 {
+		t.Fatalf("first get: %v %v", v, ok)
+	}
+	// Without refresh, another 50ms would expire (80ms total from add).
+	// With refresh on Get, should still be alive after another 50ms.
+	time.Sleep(50 * time.Millisecond)
+	if v, ok := c.Get("a"); !ok || v != 1 {
+		t.Fatalf("expected sliding TTL to keep entry alive, got %v %v", v, ok)
+	}
+}


### PR DESCRIPTION
## What

`expirable.LRU.Get` renews the entry TTL on a successful lookup (sliding expiration), re-bucketing the entry the same way `Add` does for updates.

## Why

Active keys were expiring while still being read. Callers expect "get keeps it warm" for session-style caches. See #186.

## Test

- `TestGetRefreshesTTL`