### PR TITLE
expirable: release the lock before calling onEvict

### DIFF
--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -25,6 +25,11 @@ type LRU[K comparable, V any] struct {
 	ttl  time.Duration
 	done chan struct{}
 
+	// evictedKeys and evictedVals buffer evictions collected while mu is
+	// held, so onEvict can be called after the caller releases the lock.
+	evictedKeys []K
+	evictedVals []V
+
 	// buckets for expiration
 	buckets []bucket[K, V]
 	// uint8 because it's number between 0 and numBuckets
@@ -85,10 +90,10 @@ func NewLRU[K comparable, V any](size int, onEvict EvictCallback[K, V], ttl time
 // onEvict is called for each evicted key.
 func (c *LRU[K, V]) Purge() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	for k, v := range c.items {
 		if c.onEvict != nil {
-			c.onEvict(k, v.Value)
+			c.evictedKeys = append(c.evictedKeys, k)
+			c.evictedVals = append(c.evictedVals, v.Value)
 		}
 		delete(c.items, k)
 	}
@@ -98,6 +103,9 @@ func (c *LRU[K, V]) Purge() {
 		}
 	}
 	c.evictList.Init()
+	ks, vs := c.takeEvicted()
+	c.mu.Unlock()
+	c.invokeEvicted(ks, vs)
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
@@ -105,7 +113,6 @@ func (c *LRU[K, V]) Purge() {
 // or the size was not exceeded.
 func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	now := time.Now()
 
 	// Check for existing item
@@ -115,6 +122,7 @@ func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 		ent.Value = value
 		ent.ExpiresAt = now.Add(c.ttl)
 		c.addToBucket(ent)
+		c.mu.Unlock()
 		return false
 	}
 
@@ -128,6 +136,9 @@ func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 	if evict {
 		c.removeOldest()
 	}
+	ks, vs := c.takeEvicted()
+	c.mu.Unlock()
+	c.invokeEvicted(ks, vs)
 	return evict
 }
 
@@ -176,22 +187,26 @@ func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
 // key was contained.
 func (c *LRU[K, V]) Remove(key K) bool {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	if ent, ok := c.items[key]; ok {
+	ent, ok := c.items[key]
+	if ok {
 		c.removeElement(ent)
-		return true
 	}
-	return false
+	ks, vs := c.takeEvicted()
+	c.mu.Unlock()
+	c.invokeEvicted(ks, vs)
+	return ok
 }
 
 // RemoveOldest removes the oldest item from the cache.
 func (c *LRU[K, V]) RemoveOldest() (key K, value V, ok bool) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if ent := c.evictList.Back(); ent != nil {
 		c.removeElement(ent)
-		return ent.Key, ent.Value, true
+		key, value, ok = ent.Key, ent.Value, true
 	}
+	ks, vs := c.takeEvicted()
+	c.mu.Unlock()
+	c.invokeEvicted(ks, vs)
 	return
 }
 
@@ -247,9 +262,9 @@ func (c *LRU[K, V]) Len() int {
 // Resize changes the cache size. Size of 0 means unlimited.
 func (c *LRU[K, V]) Resize(size int) (evicted int) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if size <= 0 {
 		c.size = 0
+		c.mu.Unlock()
 		return 0
 	}
 	diff := c.evictList.Length() - size
@@ -260,6 +275,9 @@ func (c *LRU[K, V]) Resize(size int) (evicted int) {
 		c.removeOldest()
 	}
 	c.size = size
+	ks, vs := c.takeEvicted()
+	c.mu.Unlock()
+	c.invokeEvicted(ks, vs)
 	return diff
 }
 
@@ -284,12 +302,34 @@ func (c *LRU[K, V]) removeOldest() {
 }
 
 // removeElement is used to remove a given list element from the cache. Has to be called with lock!
+// It buffers the evicted key/value on c.evictedKeys/c.evictedVals rather than calling onEvict
+// directly, so callers can invoke onEvict after releasing the lock. A callback that itself calls
+// back into the cache would otherwise deadlock on c.mu.
 func (c *LRU[K, V]) removeElement(e *internal.Entry[K, V]) {
 	c.evictList.Remove(e)
 	delete(c.items, e.Key)
 	c.removeFromBucket(e)
 	if c.onEvict != nil {
-		c.onEvict(e.Key, e.Value)
+		c.evictedKeys = append(c.evictedKeys, e.Key)
+		c.evictedVals = append(c.evictedVals, e.Value)
+	}
+}
+
+// takeEvicted returns and clears the evictions buffered by removeElement/Purge since the last
+// call. Has to be called with lock!
+func (c *LRU[K, V]) takeEvicted() (keys []K, vals []V) {
+	if len(c.evictedKeys) == 0 {
+		return nil, nil
+	}
+	keys, vals = c.evictedKeys, c.evictedVals
+	c.evictedKeys, c.evictedVals = nil, nil
+	return keys, vals
+}
+
+// invokeEvicted calls onEvict for each buffered eviction. Must be called without c.mu held.
+func (c *LRU[K, V]) invokeEvicted(keys []K, vals []V) {
+	for i := range keys {
+		c.onEvict(keys[i], vals[i])
 	}
 }
 
@@ -325,7 +365,9 @@ func (c *LRU[K, V]) deleteExpired() {
 		c.removeElement(ent)
 	}
 	c.nextCleanupBucket = (c.nextCleanupBucket + 1) % numBuckets
+	ks, vs := c.takeEvicted()
 	c.mu.Unlock()
+	c.invokeEvicted(ks, vs)
 }
 
 // addToBucket adds entry to expire bucket so that it will be cleaned up when the time comes. Has to be called with lock!

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -622,3 +622,81 @@ func TestCache_RestartGoRoutine(t *testing.T) {
 		t.Errorf("expected keys to be empty")
 	}
 }
+
+// runWithDeadlockGuard runs fn in a goroutine and fails the test if fn hasn't returned
+// within the timeout, instead of hanging the whole test binary on a real deadlock.
+func runWithDeadlockGuard(t *testing.T, timeout time.Duration, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("deadlock: onEvict callback did not return in time, likely still holding the cache lock")
+	}
+}
+
+// TestLRU_OnEvictReentrantOnRemove reproduces the exact repro from the reported issue: an
+// onEvict callback that calls back into the cache from Remove must not deadlock on the
+// cache's own lock.
+func TestLRU_OnEvictReentrantOnRemove(t *testing.T) {
+	var lc *LRU[string, string]
+	var evictedLen int
+	lc = NewLRU(10, func(string, string) {
+		evictedLen = lc.Len()
+	}, time.Minute)
+
+	lc.Add("k", "v")
+	runWithDeadlockGuard(t, 2*time.Second, func() {
+		lc.Remove("k")
+	})
+	if evictedLen != 0 {
+		t.Fatalf("expected onEvict to see an empty cache, got len %d", evictedLen)
+	}
+}
+
+// TestLRU_OnEvictReentrantOnSizeEviction covers the other path removeElement is reached
+// from: Add evicting the oldest entry once the cache is over capacity.
+func TestLRU_OnEvictReentrantOnSizeEviction(t *testing.T) {
+	var lc *LRU[int, int]
+	var sawDuringEvict int
+	var reAdded bool
+	lc = NewLRU(1, func(int, int) {
+		sawDuringEvict = lc.Len()
+		if !reAdded {
+			reAdded = true
+			lc.Add(-1, -1) // re-add from inside the callback, another path back into the lock
+		}
+	}, time.Minute)
+
+	lc.Add(1, 1)
+	runWithDeadlockGuard(t, 2*time.Second, func() {
+		lc.Add(2, 2)
+	})
+	// Capacity is 1, so once the evicted entry is gone the newest addition
+	// already occupies the only slot: the callback sees a cache of length 1,
+	// not 0.
+	if sawDuringEvict != 1 {
+		t.Fatalf("expected onEvict to see the new entry already in place, got len %d", sawDuringEvict)
+	}
+	if _, ok := lc.Peek(-1); !ok {
+		t.Fatalf("expected the callback's own Add to have taken effect")
+	}
+}
+
+// TestLRU_OnEvictReentrantOnPurge covers Purge, which used to call onEvict inline while
+// iterating c.items under the lock.
+func TestLRU_OnEvictReentrantOnPurge(t *testing.T) {
+	var lc *LRU[string, string]
+	lc = NewLRU(10, func(string, string) {
+		lc.Contains("k") // any locking call back into the cache
+	}, time.Minute)
+
+	lc.Add("k", "v")
+	runWithDeadlockGuard(t, 2*time.Second, func() {
+		lc.Purge()
+	})
+}


### PR DESCRIPTION
Closes #230.

`expirable.LRU` invokes `onEvict` from `removeElement` while `c.mu` is still held. Any callback that touches the cache, whether it's a read like `Len()`/`Peek()`, or a write like `Add()`/`Remove()`, deadlocks on that same lock. The non-expirable `lru.Cache` in this repository already avoids this: it collects the evicted key/value under the lock and calls the callback only after releasing it.

`removeElement` now appends the evicted key/value to a pair of buffer slices on the `LRU` struct instead of calling `onEvict` directly. Every path that can reach `removeElement` (`Add`'s size eviction, `Remove`, `RemoveOldest`, `Resize`, `Purge`, and the TTL cleanup goroutine's `deleteExpired`) drains that buffer and invokes `onEvict` once the lock is released, matching the pattern `lru.Cache` uses.

Added three tests covering the three shapes this bug takes: a callback re-entering via `Remove`, via size-based eviction in `Add` (including the callback writing back into the cache), and via `Purge`. Each is wrapped in a timeout guard so a regression fails the test instead of hanging the whole suite.

Ran the full suite with `-race`, plus `golangci-lint run ./expirable/...` and `gofmt` on the touched files, all clean.
