### PR TITLE
fix: invoke expirable onEvict callbacks outside the cache lock

### DIFF
--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -10,7 +10,16 @@ import (
 	"github.com/hashicorp/golang-lru/v2/internal"
 )
 
-// EvictCallback is used to get a callback when a cache entry is evicted
+// EvictCallback is used to get a callback when a cache entry is evicted.
+//
+// Callbacks run in the goroutine that caused the eviction: for explicit
+// removals (Add, Remove, RemoveOldest, Purge, Resize) they complete before
+// the method returns; for expired entries they run in the background cleanup
+// goroutine. They are always invoked outside the cache's internal lock, so
+// they may safely re-enter the cache (e.g. call Get or Len). Because no lock
+// is held while a callback runs, other goroutines may have mutated the cache
+// by then, so callbacks must not assume they observe a consistent snapshot
+// of the cache.
 type EvictCallback[K comparable, V any] func(key K, value V)
 
 // LRU implements a thread-safe LRU with expirable entries.
@@ -51,6 +60,9 @@ const numBuckets = 100
 // Size parameter set to 0 makes cache of unlimited size, e.g. turns LRU mechanism off.
 //
 // Providing 0 TTL turns expiring off.
+//
+// onEvict, if non-nil, is invoked for each evicted entry outside the cache's
+// internal lock; see EvictCallback for the guarantees callbacks get.
 //
 // Delete expired entries every 1/100th of ttl value. Goroutine which deletes expired entries runs indefinitely.
 func NewLRU[K comparable, V any](size int, onEvict EvictCallback[K, V], ttl time.Duration) *LRU[K, V] {
@@ -101,7 +113,7 @@ func (c *LRU[K, V]) fireCallbacks(evicted []evictedEntry[K, V]) {
 }
 
 // Purge clears the cache completely.
-// onEvict is called for each evicted key.
+// onEvict is called for each evicted key, outside the cache's internal lock.
 func (c *LRU[K, V]) Purge() {
 	var evicted []evictedEntry[K, V]
 	c.mu.Lock()
@@ -124,6 +136,8 @@ func (c *LRU[K, V]) Purge() {
 // Add adds a value to the cache. Returns true if an eviction occurred.
 // Returns false if there was no eviction: the item was already in the cache,
 // or the size was not exceeded.
+// If an eviction occurred, onEvict is invoked for the evicted entry outside
+// the cache's internal lock.
 func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()
@@ -198,7 +212,8 @@ func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
 }
 
 // Remove removes the provided key from the cache, returning if the
-// key was contained.
+// key was contained. If it was, onEvict is invoked for the removed
+// entry outside the cache's internal lock.
 func (c *LRU[K, V]) Remove(key K) bool {
 	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()
@@ -214,6 +229,7 @@ func (c *LRU[K, V]) Remove(key K) bool {
 }
 
 // RemoveOldest removes the oldest item from the cache.
+// If there was one, onEvict is invoked for it outside the cache's internal lock.
 func (c *LRU[K, V]) RemoveOldest() (key K, value V, ok bool) {
 	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()
@@ -278,6 +294,7 @@ func (c *LRU[K, V]) Len() int {
 }
 
 // Resize changes the cache size. Size of 0 means unlimited.
+// onEvict is invoked for each evicted entry outside the cache's internal lock.
 func (c *LRU[K, V]) Resize(size int) (evicted int) {
 	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()

--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -81,16 +81,35 @@ func NewLRU[K comparable, V any](size int, onEvict EvictCallback[K, V], ttl time
 	return &res
 }
 
+// evictedEntry is a snapshot of a removed entry, kept so that the onEvict
+// callback can be invoked after the lock is released.
+type evictedEntry[K comparable, V any] struct {
+	key   K
+	value V
+}
+
+// fireCallbacks invokes the onEvict callback for each evicted entry.
+// It must be called without holding c.mu so that callbacks can safely
+// re-enter the cache.
+func (c *LRU[K, V]) fireCallbacks(evicted []evictedEntry[K, V]) {
+	if c.onEvict == nil {
+		return
+	}
+	for _, e := range evicted {
+		c.onEvict(e.key, e.value)
+	}
+}
+
 // Purge clears the cache completely.
 // onEvict is called for each evicted key.
 func (c *LRU[K, V]) Purge() {
+	var evicted []evictedEntry[K, V]
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	for k, v := range c.items {
-		if c.onEvict != nil {
-			c.onEvict(k, v.Value)
-		}
 		delete(c.items, k)
+		if c.onEvict != nil {
+			evicted = append(evicted, evictedEntry[K, V]{key: k, value: v.Value})
+		}
 	}
 	for _, b := range c.buckets {
 		for _, ent := range b.entries {
@@ -98,14 +117,20 @@ func (c *LRU[K, V]) Purge() {
 		}
 	}
 	c.evictList.Init()
+	c.mu.Unlock()
+	c.fireCallbacks(evicted)
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
 // Returns false if there was no eviction: the item was already in the cache,
 // or the size was not exceeded.
 func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
+	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	defer func() {
+		c.mu.Unlock()
+		c.fireCallbacks(evictedEntries)
+	}()
 	now := time.Now()
 
 	// Check for existing item
@@ -126,7 +151,7 @@ func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 	evict := c.size > 0 && c.evictList.Length() > c.size
 	// Verify size not exceeded
 	if evict {
-		c.removeOldest()
+		c.removeOldest(&evictedEntries)
 	}
 	return evict
 }
@@ -175,10 +200,14 @@ func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
 // Remove removes the provided key from the cache, returning if the
 // key was contained.
 func (c *LRU[K, V]) Remove(key K) bool {
+	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	defer func() {
+		c.mu.Unlock()
+		c.fireCallbacks(evictedEntries)
+	}()
 	if ent, ok := c.items[key]; ok {
-		c.removeElement(ent)
+		c.removeElement(ent, &evictedEntries)
 		return true
 	}
 	return false
@@ -186,10 +215,14 @@ func (c *LRU[K, V]) Remove(key K) bool {
 
 // RemoveOldest removes the oldest item from the cache.
 func (c *LRU[K, V]) RemoveOldest() (key K, value V, ok bool) {
+	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	defer func() {
+		c.mu.Unlock()
+		c.fireCallbacks(evictedEntries)
+	}()
 	if ent := c.evictList.Back(); ent != nil {
-		c.removeElement(ent)
+		c.removeElement(ent, &evictedEntries)
 		return ent.Key, ent.Value, true
 	}
 	return
@@ -246,8 +279,12 @@ func (c *LRU[K, V]) Len() int {
 
 // Resize changes the cache size. Size of 0 means unlimited.
 func (c *LRU[K, V]) Resize(size int) (evicted int) {
+	var evictedEntries []evictedEntry[K, V]
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	defer func() {
+		c.mu.Unlock()
+		c.fireCallbacks(evictedEntries)
+	}()
 	if size <= 0 {
 		c.size = 0
 		return 0
@@ -257,7 +294,7 @@ func (c *LRU[K, V]) Resize(size int) (evicted int) {
 		diff = 0
 	}
 	for i := 0; i < diff; i++ {
-		c.removeOldest()
+		c.removeOldest(&evictedEntries)
 	}
 	c.size = size
 	return diff
@@ -277,25 +314,28 @@ func (c *LRU[K, V]) Close() {
 }
 
 // removeOldest removes the oldest item from the cache. Has to be called with lock!
-func (c *LRU[K, V]) removeOldest() {
+func (c *LRU[K, V]) removeOldest(evicted *[]evictedEntry[K, V]) {
 	if ent := c.evictList.Back(); ent != nil {
-		c.removeElement(ent)
+		c.removeElement(ent, evicted)
 	}
 }
 
 // removeElement is used to remove a given list element from the cache. Has to be called with lock!
-func (c *LRU[K, V]) removeElement(e *internal.Entry[K, V]) {
+// The removed entry is recorded in evicted instead of invoking onEvict
+// directly, so the callback can run after the lock is released.
+func (c *LRU[K, V]) removeElement(e *internal.Entry[K, V], evicted *[]evictedEntry[K, V]) {
 	c.evictList.Remove(e)
 	delete(c.items, e.Key)
 	c.removeFromBucket(e)
 	if c.onEvict != nil {
-		c.onEvict(e.Key, e.Value)
+		*evicted = append(*evicted, evictedEntry[K, V]{key: e.Key, value: e.Value})
 	}
 }
 
 // deleteExpired deletes expired records from the oldest bucket, waiting for the newest entry
 // in it to expire first.
 func (c *LRU[K, V]) deleteExpired() {
+	var evicted []evictedEntry[K, V]
 	c.mu.Lock()
 
 	// grab done channel to detect Closes
@@ -322,10 +362,11 @@ func (c *LRU[K, V]) deleteExpired() {
 		}
 	}
 	for _, ent := range c.buckets[bucketIdx].entries {
-		c.removeElement(ent)
+		c.removeElement(ent, &evicted)
 	}
 	c.nextCleanupBucket = (c.nextCleanupBucket + 1) % numBuckets
 	c.mu.Unlock()
+	c.fireCallbacks(evicted)
 }
 
 // addToBucket adds entry to expire bucket so that it will be cleaned up when the time comes. Has to be called with lock!

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package expirable

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -620,5 +621,100 @@ func TestCache_RestartGoRoutine(t *testing.T) {
 	keys := cache.Keys()
 	if len(keys) != 0 {
 		t.Errorf("expected keys to be empty")
+	}
+}
+
+// runWithTimeout runs fn and fails the test if it does not return within the
+// timeout, e.g. because it deadlocked.
+func runWithTimeout(t *testing.T, name string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s deadlocked: onEvict re-entry blocked on the cache lock", name)
+	}
+}
+
+// TestOnEvictReentrant verifies that the onEvict callback may safely
+// re-enter the cache. Previously the callback was invoked while holding the
+// cache lock, so any re-entrant call deadlocked.
+func TestOnEvictReentrant(t *testing.T) {
+	newCache := func() *LRU[string, string] {
+		var c *LRU[string, string]
+		c = NewLRU[string, string](2, func(k, v string) {
+			// Re-enter the cache from inside the eviction callback.
+			c.Len()
+			c.Get("other")
+			c.Keys()
+		}, time.Minute)
+		return c
+	}
+
+	t.Run("Remove", func(t *testing.T) {
+		c := newCache()
+		c.Add("k", "v")
+		runWithTimeout(t, "Remove", func() { c.Remove("k") })
+	})
+
+	t.Run("Add eviction", func(t *testing.T) {
+		c := newCache()
+		c.Add("a", "1")
+		c.Add("b", "2")
+		runWithTimeout(t, "Add", func() { c.Add("c", "3") }) // evicts "a"
+	})
+
+	t.Run("RemoveOldest", func(t *testing.T) {
+		c := newCache()
+		c.Add("a", "1")
+		runWithTimeout(t, "RemoveOldest", func() { c.RemoveOldest() })
+	})
+
+	t.Run("Purge", func(t *testing.T) {
+		c := newCache()
+		c.Add("a", "1")
+		runWithTimeout(t, "Purge", func() { c.Purge() })
+	})
+
+	t.Run("Resize", func(t *testing.T) {
+		c := newCache()
+		c.Add("a", "1")
+		c.Add("b", "2")
+		runWithTimeout(t, "Resize", func() { c.Resize(1) }) // evicts "a"
+	})
+
+	t.Run("deleteExpired", func(t *testing.T) {
+		var calls int32
+		var c *LRU[string, string]
+		c = NewLRU[string, string](2, func(k, v string) {
+			atomic.AddInt32(&calls, 1)
+			c.Len() // re-enter from the cleanup goroutine
+		}, 20*time.Millisecond)
+		c.Add("k", "v")
+
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if atomic.LoadInt32(&calls) > 0 {
+				return // callback ran and re-entered without deadlocking
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		t.Fatal("eviction callback was never invoked by the cleanup goroutine")
+	})
+}
+
+// TestOnEvictStillSynced verifies the callback keeps running synchronously,
+// before the removing method returns.
+func TestOnEvictStillSynced(t *testing.T) {
+	var called bool
+	c := NewLRU[string, string](2, func(k, v string) { called = true }, time.Minute)
+	c.Add("k", "v")
+	c.Remove("k")
+	if !called {
+		t.Fatal("onEvict must run before Remove returns")
 	}
 }


### PR DESCRIPTION
## Description

`expirable.LRU` invoked the `onEvict` callback while holding the internal mutex, so any callback that re-entered the cache (calling `Len()`, `Get()`, or issuing another removal from the callback) deadlocked. Re-entering the cache from an eviction callback is a common pattern, e.g. for caches that maintain their own bookkeeping on eviction.

This change snapshots evicted entries under the lock and invokes the callback after the lock is released, mirroring what the non-expirable `lru.Cache` in this repository already does. The callback still runs synchronously before the removing method returns, so existing ordering guarantees are preserved.

## Related Issue

Fixes #230

## How Has This Been Tested?

- Reproduced the deadlock from the issue on current `main` before the change; confirmed it is gone after the change.
- Added `TestOnEvictReentrant`, a regression test covering every eviction path (`Add` capacity eviction, `Remove`, `RemoveOldest`, `Purge`, `Resize`, and the background `deleteExpired` goroutine) with a re-entrant callback, guarded by a timeout so a deadlock fails the test instead of hanging it.
- Added `TestOnEvictStillSynced` asserting the callback still completes before `Remove` returns.
- Full test suite passes with `-race` (`go test -race ./...`) on macOS arm64, go1.25.3.

### Contributor Checklist
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../CONTRIBUTING.md#ai-usage).