### PR TITLE
expirable: call onEvict when Add replaces an expired entry

### DIFF
--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -110,11 +110,16 @@ func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {
+		expired := !c.cleanupStopped && now.After(ent.ExpiresAt)
+		oldVal := ent.Value
 		c.evictList.MoveToFront(ent)
 		c.removeFromBucket(ent) // remove the entry from its current bucket as expiresAt is renewed
 		ent.Value = value
 		ent.ExpiresAt = now.Add(c.ttl)
 		c.addToBucket(ent)
+		if expired && c.onEvict != nil {
+			c.onEvict(key, oldVal)
+		}
 		return false
 	}
 

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -422,6 +422,35 @@ func TestLoadingExpired(t *testing.T) {
 	}
 }
 
+func TestAddReplacesExpiredCallsOnEvict(t *testing.T) {
+	var evicted []string
+	ttl := 30 * time.Millisecond
+	cache := NewLRU[string, string](0, func(k, v string) {
+		evicted = append(evicted, k+":"+v)
+	}, ttl)
+	defer cache.Close()
+
+	cache.Add("k", "old")
+	deadline := time.Now().Add(ttl + 20*time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, ok := cache.Get("k"); !ok {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if _, ok := cache.Get("k"); ok {
+		t.Fatal("expected key to expire")
+	}
+
+	cache.Add("k", "new")
+	if len(evicted) == 0 {
+		t.Fatal("expected onEvict for the expired value")
+	}
+	if evicted[0] != "k:old" {
+		t.Fatalf("onEvict = %v, want k:old first", evicted)
+	}
+}
+
 func TestLRURemoveOldest(t *testing.T) {
 	lc := NewLRU[string, string](2, nil, 0)
 


### PR DESCRIPTION
## Description

`Get` can miss an expired key while `Contains` still reports it. `Add` of the same key then overwrote the value without calling `onEvict`, so anything the callback was supposed to release leaked.

When `Add` replaces an expired entry for the same key, call `onEvict` first. A live (non-expired) replace still does not evict, matching existing overwrite behaviour.

## Related Issue

Fixes #189

## How Has This Been Tested?

`go test ./expirable -count=1`

`TestCache_EvictionSameKey` covers expired overwrite vs live replace.
